### PR TITLE
fix: 修复导出JPG图片到Excel时可能无限循环的问题

### DIFF
--- a/src/Magicodes.ExporterAndImporter.Core/Extension/Extension.cs
+++ b/src/Magicodes.ExporterAndImporter.Core/Extension/Extension.cs
@@ -312,7 +312,15 @@ namespace Magicodes.ExporterAndImporter.Core.Extension
                 System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
             var wc = new System.Net.WebClient();
             wc.Proxy = null;
-            return new Bitmap(wc.OpenRead(url));
+            var image = new Bitmap(wc.OpenRead(url));
+
+            if (image.HorizontalResolution == 0 && image.VerticalResolution == 0)
+            {
+                var gImage = Graphics.FromImage(image);
+                image.SetResolution(gImage.DpiX, gImage.DpiY);
+            }
+
+            return image;
         }
 
         /// <summary>

--- a/src/Magicodes.ExporterAndImporter.Tests/ExcelExporter_Tests.cs
+++ b/src/Magicodes.ExporterAndImporter.Tests/ExcelExporter_Tests.cs
@@ -1019,5 +1019,29 @@ namespace Magicodes.ExporterAndImporter.Tests
             }
         }
 
+        [Fact(DisplayName = "Linux环境时导出JPG图片到Excel的测试", Timeout = 10000)]
+        public async Task ExportWithJPG_Test()
+        {
+            var imagePath = Path.Combine(Directory.GetCurrentDirectory(), "TestFiles", "Images", "zero-DPI.Jpeg");
+            dynamic data = new ExpandoObject();
+            data.Datas = new List<ExpandoObject>() { };
+            dynamic row = new ExpandoObject();
+            row.Name = "好名字";
+            row.ImagePath = imagePath;
+            data.Datas.Add(row);
+
+            //模板路径
+            var tplPath = Path.Combine(Directory.GetCurrentDirectory(), "TestFiles", "ExportTemplates", "ZeroDPI.xlsx");
+            //创建Excel导出对象
+            IExportFileByTemplate exporter = new ExcelExporter();
+            //导出路径
+            var filePath = GetTestFilePath($"{nameof(ExportWithJPG_Test)}.xlsx");
+            if (File.Exists(filePath)) File.Delete(filePath);
+            //根据模板导出
+            await Task.Run(async () =>
+            {
+                await exporter.ExportByTemplate(filePath, data, tplPath);
+            });
+        }
     }
 }


### PR DESCRIPTION
## 遇到的问题

最近在工作的时候，遇到请求接口进行导出卡住不动的问题，查看导出时CPU占用飙升到百分之100，查看过去的Issue也发现了这个问题：#285 

## 运行环境

操作系统：`Centos7`
dotnet版本：.NET Core.和.NET 5均尝试过

## 复现方式

`dotnet test --filter "FullyQualifiedName=Magicodes.ExporterAndImporter.Tests.ExcelExporter_Tests.ExportWithJPGInfiniteloop_Test"`

超过设置的10秒超时时间

## 解决过程

查看Issue中提到这个问题已经解决，于是把项目中引用的库版本回滚到Issue中提到已经解决该问题的版本`2.5.4.3`版本，问题确实不存在了，但是由于回滚到之前的版本会出现一些老版本中存在的问题，比如单元格自动换行失效的问题，所以还是需要使用新版本

考虑到项目上的问题急需解决，目前的解决方案是将图片转换成`PNG`格式再进行导出，但考虑到有潜在的使用风险，所以还是需要调整库的代码，避免之后出现类似的问题

debug之后发现和上面Issue中提到的一样，因为没有获取到图片的`DPI`信息，导致代码进入死循环，于是调整了代码，使得获取到的图片`DPI`为0的时候，为其重新赋值

## 参考资料

**为什么部分JPG图片的DPI会为0**：

由于JPG格式的图片在经过一些处理之后，可能会出现丢失DPI信息的情况，比如：
[Python base64 encode/decode removing DPI information from image](https://stackoverflow.com/questions/64700240/python-base64-encode-decode-removing-dpi-information-from-image)

**这可能是一个`System.Drawing.Common`库的问题**：
https://github.com/JanKallman/EPPlus/issues/322

**`System.Drawing.Common`已经被标记为只应在Windows环境下使用**：

值得注意的是，由于`System.Drawing.Common`已经被标记为只应在Windows环境下使用，所以是否将该库替换成`ImageSharp`等库也是一个值得考虑的问题：

[System.Drawing.Common only supported on Windows](https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only)
[Make System.Drawing.Common only supported on Windows](https://github.com/dotnet/designs/blob/main/accepted/2021/system-drawing-win-only/system-drawing-win-only.md)
