### PR TITLE
use skiasharp font instead of SixLabor fonts

### DIFF
--- a/src/EPPlus/EPPlus/ExcelRangeBase.cs
+++ b/src/EPPlus/EPPlus/ExcelRangeBase.cs
@@ -30,6 +30,7 @@
  * Jan Källman		    License changed GPL-->LGPL  2011-12-27
  * Eyal Seagull		    Conditional Formatting      2012-04-03
  *******************************************************************************/
+
 using OfficeOpenXml.Compatibility;
 using OfficeOpenXml.ConditionalFormatting;
 using OfficeOpenXml.DataValidation;
@@ -38,12 +39,12 @@ using OfficeOpenXml.Style;
 using OfficeOpenXml.Style.XmlAccess;
 using OfficeOpenXml.Table;
 using OfficeOpenXml.Utils;
+using SkiaSharp;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
-using SixLabors.ImageSharp;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -51,24 +52,29 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
-using SixLabors.Fonts;
 
 namespace OfficeOpenXml
 {
     /// <summary>
     /// A range of cells 
     /// </summary>
-    public partial class ExcelRangeBase : ExcelAddress, IExcelCell, IDisposable, IEnumerable<ExcelRangeBase>, IEnumerator<ExcelRangeBase>
+    public partial class ExcelRangeBase : ExcelAddress, IExcelCell, IDisposable, IEnumerable<ExcelRangeBase>,
+        IEnumerator<ExcelRangeBase>
     {
         /// <summary>
         /// Reference to the worksheet
         /// </summary>
         protected ExcelWorksheet _worksheet;
+
         internal ExcelWorkbook _workbook = null;
+
         private delegate void _changeProp(ExcelRangeBase range, _setValue method, object value);
+
         private delegate void _setValue(ExcelRangeBase range, object value, int row, int col);
+
         private _changeProp _changePropMethod;
         private int _styleID;
+
         private class CopiedCell
         {
             internal int Row { get; set; }
@@ -81,7 +87,9 @@ namespace OfficeOpenXml
             internal ExcelComment Comment { get; set; }
             internal Byte Flag { get; set; }
         }
+
         #region Constructors
+
         internal ExcelRangeBase(ExcelWorksheet xlWorksheet)
         {
             _worksheet = xlWorksheet;
@@ -89,6 +97,7 @@ namespace OfficeOpenXml
             _workbook = _worksheet.Workbook;
             SetDelegate();
         }
+
         /// <summary>
         /// On change address handler
         /// </summary>
@@ -98,8 +107,10 @@ namespace OfficeOpenXml
             {
                 SetRCFromTable(_workbook._package, null);
             }
+
             SetDelegate();
         }
+
         internal ExcelRangeBase(ExcelWorksheet xlWorksheet, string address) :
             base(xlWorksheet == null ? "" : xlWorksheet.Name, address)
         {
@@ -109,6 +120,7 @@ namespace OfficeOpenXml
             if (string.IsNullOrEmpty(_ws)) _ws = _worksheet == null ? "" : _worksheet.Name;
             SetDelegate();
         }
+
         internal ExcelRangeBase(ExcelWorkbook wb, ExcelWorksheet xlWorksheet, string address, bool isName) :
             base(xlWorksheet == null ? "" : xlWorksheet.Name, address, isName)
         {
@@ -118,12 +130,16 @@ namespace OfficeOpenXml
             if (string.IsNullOrEmpty(_ws)) _ws = (xlWorksheet == null ? null : xlWorksheet.Name);
             SetDelegate();
         }
+
         #endregion
-        #region Set Value Delegates        
+
+        #region Set Value Delegates
+
         private static _changeProp _setUnknownProp = SetUnknown;
         private static _changeProp _setSingleProp = SetSingle;
         private static _changeProp _setRangeProp = SetRange;
         private static _changeProp _setMultiProp = SetMultiRange;
+
         private void SetDelegate()
         {
             if (_fromRow == -1)
@@ -146,6 +162,7 @@ namespace OfficeOpenXml
                 _changePropMethod = SetMultiRange;
             }
         }
+
         /// <summary>
         /// We dont know the address yet. Set the delegate first time a property is set.
         /// </summary>
@@ -159,9 +176,11 @@ namespace OfficeOpenXml
             {
                 range.SetToSelectedRange();
             }
+
             range.SetDelegate();
             range._changePropMethod(range, valueMethod, value);
         }
+
         /// <summary>
         /// Set a single cell
         /// </summary>
@@ -172,6 +191,7 @@ namespace OfficeOpenXml
         {
             valueMethod(range, value, range._fromRow, range._fromCol);
         }
+
         /// <summary>
         /// Set a range
         /// </summary>
@@ -182,6 +202,7 @@ namespace OfficeOpenXml
         {
             range.SetValueAddress(range, valueMethod, value);
         }
+
         /// <summary>
         /// Set a multirange (A1:A2,C1:C2)
         /// </summary>
@@ -196,6 +217,7 @@ namespace OfficeOpenXml
                 range.SetValueAddress(address, valueMethod, value);
             }
         }
+
         /// <summary>
         /// Set the property for an address
         /// </summary>
@@ -205,7 +227,9 @@ namespace OfficeOpenXml
         private void SetValueAddress(ExcelAddress address, _setValue valueMethod, object value)
         {
             IsRangeValid("");
-            if (_fromRow == 1 && _fromCol == 1 && _toRow == ExcelPackage.MaxRows && _toCol == ExcelPackage.MaxColumns)  //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
+            if (_fromRow == 1 && _fromCol == 1 && _toRow == ExcelPackage.MaxRows &&
+                _toCol == ExcelPackage
+                    .MaxColumns) //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
             {
                 throw (new ArgumentException("Can't reference all cells. Please use the indexer to set the range"));
             }
@@ -214,7 +238,8 @@ namespace OfficeOpenXml
                 if (value is object[,] && valueMethod == Set_Value)
                 {
                     // only simple set value is supported for bulk copy
-                    _worksheet.SetRangeValueInner(address.Start.Row, address.Start.Column, address.End.Row, address.End.Column, (object[,])value);
+                    _worksheet.SetRangeValueInner(address.Start.Row, address.Start.Column, address.End.Row,
+                        address.End.Column, (object[,])value);
                 }
                 else
                 {
@@ -228,8 +253,11 @@ namespace OfficeOpenXml
                 }
             }
         }
+
         #endregion
+
         #region Set property methods
+
         private static _setValue _setStyleIdDelegate = Set_StyleID;
         private static _setValue _setValueDelegate = Set_Value;
         private static _setValue _setHyperLinkDelegate = Set_HyperLink;
@@ -241,10 +269,12 @@ namespace OfficeOpenXml
         {
             range._worksheet.SetStyleInner(row, col, (int)value);
         }
+
         private static void Set_StyleName(ExcelRangeBase range, object value, int row, int col)
         {
             range._worksheet.SetStyleInner(row, col, range._styleID);
         }
+
         private static void Set_Value(ExcelRangeBase range, object value, int row, int col)
         {
             var sfi = range._worksheet._formulas.GetValue(row, col);
@@ -252,9 +282,11 @@ namespace OfficeOpenXml
             {
                 range.SplitFormulas(range._worksheet.Cells[row, col]);
             }
+
             if (sfi != null) range._worksheet._formulas.SetValue(row, col, string.Empty);
             range._worksheet.SetValueInner(row, col, value);
         }
+
         private static void Set_Formula(ExcelRangeBase range, object value, int row, int col)
         {
             var f = range._worksheet._formulas.GetValue(row, col);
@@ -267,11 +299,13 @@ namespace OfficeOpenXml
             }
             else
             {
-                if (formula[0] == '=') value = formula.Substring(1, formula.Length - 1); // remove any starting equalsign.
+                if (formula[0] == '=')
+                    value = formula.Substring(1, formula.Length - 1); // remove any starting equalsign.
                 range._worksheet._formulas.SetValue(row, col, formula);
                 range._worksheet.SetValueInner(row, col, null);
             }
         }
+
         /// <summary>
         /// Handles shared formulas
         /// </summary>
@@ -281,16 +315,20 @@ namespace OfficeOpenXml
         /// <param name="IsArray">If the forumla is an array formula.</param>
         private static void Set_SharedFormula(ExcelRangeBase range, string value, ExcelAddress address, bool IsArray)
         {
-            if (range._fromRow == 1 && range._fromCol == 1 && range._toRow == ExcelPackage.MaxRows && range._toCol == ExcelPackage.MaxColumns)  //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
+            if (range._fromRow == 1 && range._fromCol == 1 && range._toRow == ExcelPackage.MaxRows &&
+                range._toCol ==
+                ExcelPackage.MaxColumns) //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
             {
                 throw (new InvalidOperationException("Can't set a formula for the entire worksheet"));
             }
-            else if (address.Start.Row == address.End.Row && address.Start.Column == address.End.Column && !IsArray)             //is it really a shared formula? Arrayformulas can be one cell only
+            else if (address.Start.Row == address.End.Row && address.Start.Column == address.End.Column &&
+                     !IsArray) //is it really a shared formula? Arrayformulas can be one cell only
             {
                 //Nope, single cell. Set the formula
                 Set_Formula(range, value, address.Start.Row, address.Start.Column);
                 return;
             }
+
             range.CheckAndSplitSharedFormula(address);
             ExcelWorksheet.Formulas f = new ExcelWorksheet.Formulas(SourceCodeTokenizer.Default);
             f.Formula = value;
@@ -312,6 +350,7 @@ namespace OfficeOpenXml
                 }
             }
         }
+
         private static void Set_HyperLink(ExcelRangeBase range, object value, int row, int col)
         {
             if (value is Uri)
@@ -337,24 +376,30 @@ namespace OfficeOpenXml
                 range._worksheet.SetValueInner(row, col, (Uri)null);
             }
         }
+
         private static void Set_IsRichText(ExcelRangeBase range, object value, int row, int col)
         {
             range._worksheet._flags.SetFlagValue(row, col, (bool)value, CellFlags.RichText);
         }
+
         private static void Exists_Comment(ExcelRangeBase range, object value, int row, int col)
         {
             if (range._worksheet._commentsStore.Exists(row, col))
             {
-                throw (new InvalidOperationException(string.Format("Cell {0} already contain a comment.", new ExcelCellAddress(row, col).Address)));
+                throw (new InvalidOperationException(string.Format("Cell {0} already contain a comment.",
+                    new ExcelCellAddress(row, col).Address)));
             }
-
         }
+
         private static void Set_Comment(ExcelRangeBase range, object value, int row, int col)
         {
             string[] v = (string[])value;
-            range._worksheet.Comments.Add(new ExcelRangeBase(range._worksheet, GetAddress(range._fromRow, range._fromCol)), v[0], v[1]);
+            range._worksheet.Comments.Add(
+                new ExcelRangeBase(range._worksheet, GetAddress(range._fromRow, range._fromCol)), v[0], v[1]);
         }
+
         #endregion
+
         private void SetToSelectedRange()
         {
             if (_worksheet.View.SelectedRange == "")
@@ -366,6 +411,7 @@ namespace OfficeOpenXml
                 Address = _worksheet.View.SelectedRange;
             }
         }
+
         private void IsRangeValid(string type)
         {
             if (_fromRow <= 0)
@@ -378,21 +424,25 @@ namespace OfficeOpenXml
                 {
                     if (type == "")
                     {
-                        throw (new InvalidOperationException(string.Format("Range is not valid for this operation: {0}", _address)));
+                        throw (new InvalidOperationException(string.Format("Range is not valid for this operation: {0}",
+                            _address)));
                     }
                     else
                     {
-                        throw (new InvalidOperationException(string.Format("Range is not valid for {0} : {1}", type, _address)));
+                        throw (new InvalidOperationException(string.Format("Range is not valid for {0} : {1}", type,
+                            _address)));
                     }
                 }
             }
         }
+
         internal void UpdateAddress(string address)
         {
             throw new NotImplementedException();
         }
 
         #region Public Properties
+
         /// <summary>
         /// The styleobject for the range.
         /// </summary>
@@ -417,9 +467,11 @@ namespace OfficeOpenXml
                         }
                     }
                 }
+
                 return _worksheet.Workbook.Styles.GetStyleObject(s, _worksheet.PositionID, Address);
             }
         }
+
         /// <summary>
         /// The named style
         /// </summary>
@@ -452,6 +504,7 @@ namespace OfficeOpenXml
                         }
                     }
                 }
+
                 int nsID;
                 if (xfId <= 0)
                 {
@@ -461,6 +514,7 @@ namespace OfficeOpenXml
                 {
                     nsID = Style.Styles.CellXfs[xfId].XfId;
                 }
+
                 foreach (var ns in Style.Styles.NamedStyles)
                 {
                     if (ns.StyleXfId == nsID)
@@ -475,7 +529,7 @@ namespace OfficeOpenXml
             {
                 _styleID = _worksheet.Workbook.Styles.GetStyleIdFromName(value);
                 int col = _fromCol;
-                if (_fromRow == 1 && _toRow == ExcelPackage.MaxRows)    //Full column
+                if (_fromRow == 1 && _toRow == ExcelPackage.MaxRows) //Full column
                 {
                     ExcelColumn column;
                     var c = _worksheet.GetValue(0, _fromCol);
@@ -517,11 +571,13 @@ namespace OfficeOpenXml
                                 {
                                     column.ColumnMax = nextCol.ColumnMax - 1;
                                 }
+
                                 column = nextCol;
                                 cols.Next();
                             }
                         }
                     }
+
                     if (column.ColumnMax < _toCol)
                     {
                         column.ColumnMax = _toCol;
@@ -529,7 +585,8 @@ namespace OfficeOpenXml
 
                     if (_fromCol == 1 && _toCol == ExcelPackage.MaxColumns) //FullRow
                     {
-                        var rows = new CellsStoreEnumerator<ExcelCoreValue>(_worksheet._values, 1, 0, ExcelPackage.MaxRows, 0);
+                        var rows = new CellsStoreEnumerator<ExcelCoreValue>(_worksheet._values, 1, 0,
+                            ExcelPackage.MaxRows, 0);
                         rows.Next();
                         while (rows.Value._value != null)
                         {
@@ -550,7 +607,8 @@ namespace OfficeOpenXml
                     }
                 }
 
-                if (!((_fromRow == 1 && _toRow == ExcelPackage.MaxRows) || (_fromCol == 1 && _toCol == ExcelPackage.MaxColumns))) //Cell specific
+                if (!((_fromRow == 1 && _toRow == ExcelPackage.MaxRows) ||
+                      (_fromCol == 1 && _toCol == ExcelPackage.MaxColumns))) //Cell specific
                 {
                     for (int c = _fromCol; c <= _toCol; c++)
                     {
@@ -562,7 +620,8 @@ namespace OfficeOpenXml
                 }
                 else //Only set name on created cells. (uncreated cells is set on full row or full column).
                 {
-                    var cells = new CellsStoreEnumerator<ExcelCoreValue>(_worksheet._values, _fromRow, _fromCol, _toRow, _toCol);
+                    var cells = new CellsStoreEnumerator<ExcelCoreValue>(_worksheet._values, _fromRow, _fromCol, _toRow,
+                        _toCol);
                     while (cells.Next())
                     {
                         _worksheet.SetStyleInner(cells.Row, cells.Column, _styleID);
@@ -590,8 +649,10 @@ namespace OfficeOpenXml
                     }
                 }
             }
+
             return 0;
         }
+
         /// <summary>
         /// The style ID. 
         /// It is not recomended to use this one. Use Named styles as an alternative.
@@ -609,13 +670,12 @@ namespace OfficeOpenXml
                         s = _worksheet.GetStyleInner(0, _fromCol);
                     }
                 }
+
                 return s;
             }
-            set
-            {
-                _changePropMethod(this, _setStyleIdDelegate, value);
-            }
+            set { _changePropMethod(this, _setStyleIdDelegate, value); }
         }
+
         /// <summary>
         /// Set the range to a specific value
         /// </summary>
@@ -691,6 +751,7 @@ namespace OfficeOpenXml
             {
                 addr = this;
             }
+
             object[,] v = new object[addr._toRow - addr._fromRow + 1, addr._toCol - addr._fromCol + 1];
 
             for (int col = addr._fromCol; col <= addr._toCol; col++)
@@ -711,8 +772,10 @@ namespace OfficeOpenXml
                     }
                 }
             }
+
             return v;
         }
+
         private ExcelAddressBase GetAddressDim(ExcelRangeBase addr)
         {
             int fromRow, fromCol, toRow, toCol;
@@ -751,16 +814,15 @@ namespace OfficeOpenXml
                 return _worksheet.GetValueInner(_fromRow, _fromCol);
             }
         }
+
         /// <summary>
         /// Returns the formatted value.
         /// </summary>
         public string Text
         {
-            get
-            {
-                return GetFormattedText(false);
-            }
+            get { return GetFormattedText(false); }
         }
+
         /// <summary>
         /// Set the column width from the content of the range. The minimum width is the value of the ExcelWorksheet.defaultColumnWidth property.
         /// Note: Cells containing formulas must be calculated before autofit is called.
@@ -789,19 +851,19 @@ namespace OfficeOpenXml
         ///       Wrapped and merged cells are also ignored.
         ///      Hidden columns are left hidden.
         /// </summary>
-        /// <param name="MinimumWidth">Minimum column width</param>
-        /// <param name="MaximumWidth">Maximum column width</param>
-        public void AutoFitColumns(double MinimumWidth, double MaximumWidth)
+        /// <param name="minimumWidth">Minimum column width</param>
+        /// <param name="maximumWidth">Maximum column width</param>
+        public void AutoFitColumns(double minimumWidth, double maximumWidth)
         {
             if (_worksheet.Dimension == null)
             {
                 return;
             }
+
             if (_fromCol < 1 || _fromRow < 1)
             {
                 SetToSelectedRange();
             }
-            var fontCache = new Dictionary<int, Font>();
 
             bool doAdjust = _worksheet._package.DoAdjustDrawings;
             _worksheet._package.DoAdjustDrawings = false;
@@ -810,19 +872,24 @@ namespace OfficeOpenXml
             var fromCol = _fromCol > _worksheet.Dimension._fromCol ? _fromCol : _worksheet.Dimension._fromCol;
             var toCol = _toCol < _worksheet.Dimension._toCol ? _toCol : _worksheet.Dimension._toCol;
 
-            if (fromCol > toCol) return; //Issue 15383
+            if (fromCol > toCol)
+            {
+                return; //Issue 15383
+            }
 
             if (Addresses == null)
             {
-                SetMinWidth(MinimumWidth, fromCol, toCol);
+                SetMinWidth(minimumWidth, fromCol, toCol);
             }
             else
             {
                 foreach (var addr in Addresses)
                 {
-                    fromCol = addr._fromCol > _worksheet.Dimension._fromCol ? addr._fromCol : _worksheet.Dimension._fromCol;
+                    fromCol = addr._fromCol > _worksheet.Dimension._fromCol
+                        ? addr._fromCol
+                        : _worksheet.Dimension._fromCol;
                     toCol = addr._toCol < _worksheet.Dimension._toCol ? addr._toCol : _worksheet.Dimension._toCol;
-                    SetMinWidth(MinimumWidth, fromCol, toCol);
+                    SetMinWidth(minimumWidth, fromCol, toCol);
                 }
             }
 
@@ -831,92 +898,120 @@ namespace OfficeOpenXml
             if (_worksheet.AutoFilterAddress != null)
             {
                 afAddr.Add(new ExcelAddressBase(_worksheet.AutoFilterAddress._fromRow,
-                                                    _worksheet.AutoFilterAddress._fromCol,
-                                                    _worksheet.AutoFilterAddress._fromRow,
-                                                    _worksheet.AutoFilterAddress._toCol));
+                    _worksheet.AutoFilterAddress._fromCol,
+                    _worksheet.AutoFilterAddress._fromRow,
+                    _worksheet.AutoFilterAddress._toCol));
                 afAddr[afAddr.Count - 1]._ws = WorkSheet;
             }
+
             foreach (var tbl in _worksheet.Tables)
             {
                 if (tbl.AutoFilterAddress != null)
                 {
                     afAddr.Add(new ExcelAddressBase(tbl.AutoFilterAddress._fromRow,
-                                                                            tbl.AutoFilterAddress._fromCol,
-                                                                            tbl.AutoFilterAddress._fromRow,
-                                                                            tbl.AutoFilterAddress._toCol));
+                        tbl.AutoFilterAddress._fromCol,
+                        tbl.AutoFilterAddress._fromRow,
+                        tbl.AutoFilterAddress._toCol));
                     afAddr[afAddr.Count - 1]._ws = WorkSheet;
                 }
             }
 
             var styles = _worksheet.Workbook.Styles;
-            var nf = styles.Fonts[styles.CellXfs[0].FontId];
-            var fs = FontStyle.Regular;
-            if (nf.Bold) fs |= FontStyle.Bold;
-            if (nf.Italic) fs |= FontStyle.Italic;
-            var td = TextDecorations.None;
-            if (nf.UnderLine) td |= TextDecorations.Underline;
-            if (nf.Strike) td |= TextDecorations.Strikeout;
-
-            var normalSize = Convert.ToSingle(ExcelWorkbook.GetWidthPixels(nf.Name, nf.Size));
-
             foreach (var cell in this)
             {
-                if (_worksheet.Column(cell.Start.Column).Hidden)    //Issue 15338
+                if (_worksheet.Column(cell.Start.Column).Hidden) //Issue 15338
+                {
                     continue;
+                }
 
-                if (cell.Merge == true || cell.Style.WrapText) continue;
-                var fntId = styles.CellXfs[cell.StyleID].FontId;
-                Font f;
-                if (fontCache.ContainsKey(fntId))
+                if (cell.Merge || cell.Style.WrapText)
                 {
-                    f = fontCache[fntId];
+                    continue;
                 }
-                else
+
+                if (cell.Address.StartsWith("I"))
                 {
-                    var fnt = styles.Fonts[fntId];
-                    fs = FontStyle.Regular;
-                    if (fnt.Bold) fs |= FontStyle.Bold;
-                    if (fnt.Italic) fs |= FontStyle.Italic; 
-                    td = TextDecorations.None;
-                    if (fnt.UnderLine) td |= TextDecorations.Underline;
-                    if (fnt.Strike) td |= TextDecorations.Strikeout;
-                    f = SystemFonts.CreateFont(fnt.Name, CultureInfo.CurrentCulture, fnt.Size, fs);
-                    fontCache.Add(fntId, f);
                 }
+
                 var ind = styles.CellXfs[cell.StyleID].Indent;
                 var textForWidth = cell.TextForWidth;
                 var t = textForWidth + (ind > 0 && !string.IsNullOrEmpty(textForWidth) ? new string('_', ind) : "");
                 if (t.Length > 32000) t = t.Substring(0, 32000); //Issue
-                var size = TextMeasurer.Measure(t, new TextOptions(f));
-
-                double width;
-                double r = styles.CellXfs[cell.StyleID].TextRotation;
-                if (r <= 0)
+                using (var font = GetAvailableFont(t))
                 {
-                    width = (size.Width + 5) / normalSize;
-                }
-                else
-                {
-                    r = (r <= 90 ? r : r - 90);
-                    width = (((size.Width - size.Height) * Math.Abs(System.Math.Cos(System.Math.PI * r / 180.0)) + size.Height) + 5) / normalSize;
-                }
-
-                foreach (var a in afAddr)
-                {
-                    if (a.Collide(cell) != eAddressCollition.No)
+                    var normalSize =
+                        Convert.ToSingle(ExcelWorkbook.GetWidthPixels(font.Typeface.FamilyName, font.Size));
+                    using (var paint = new SKPaint(font))
                     {
-                        width += 2.25;
-                        break;
+                        paint.TextSize = font.Size;
+                        SKRect rect = SKRect.Empty;
+                        var measureWidthInPoints = paint.MeasureText(t, ref rect);
+                        double widthInPixels = measureWidthInPoints * 4 / 3;
+                        double r = styles.CellXfs[cell.StyleID].TextRotation;
+                        if (r <= 0)
+                        {
+                            widthInPixels = (widthInPixels + 5) / normalSize;
+                        }
+                        else
+                        {
+                            r = r <= 90 ? r : r - 90;
+                            widthInPixels = ((widthInPixels - rect.Size.Height) *
+                                             Math.Abs(Math.Cos(Math.PI * r / 180.0)) +
+                                             rect.Size.Height + 5) / normalSize;
+                        }
+
+                        foreach (var a in afAddr)
+                        {
+                            if (a.Collide(cell) != eAddressCollition.No)
+                            {
+                                widthInPixels += 2.25;
+                                break;
+                            }
+                        }
+
+                        if (widthInPixels > _worksheet.Column(cell._fromCol).Width)
+                        {
+                            _worksheet.Column(cell._fromCol).Width =
+                                widthInPixels > maximumWidth ? maximumWidth : widthInPixels;
+                        }
                     }
                 }
-
-                if (width > _worksheet.Column(cell._fromCol).Width)
-                {
-                    _worksheet.Column(cell._fromCol).Width = width > MaximumWidth ? MaximumWidth : width;
-                }
             }
+
             _worksheet.Drawings.AdjustWidth(drawWidths);
             _worksheet._package.DoAdjustDrawings = doAdjust;
+        }
+
+        private SKFont GetAvailableFont(string text)
+        {
+            var isAllAsciiSymbolOrChars =
+                !text.Any(c => c < 20 || c > 126); // use FangSong to measure the text that is not in english
+            var styles = _worksheet.Workbook.Styles;
+            for (int i = isAllAsciiSymbolOrChars ? 0 : 1; i < styles.Fonts.Count; i++)
+            {
+                var skFontStyle = SKFontStyle.Normal;
+                var excelFontXml = styles.Fonts[i];
+                if (excelFontXml.Bold && excelFontXml.Italic)
+                {
+                    skFontStyle = SKFontStyle.BoldItalic;
+                }
+                else if (excelFontXml.Italic)
+                {
+                    skFontStyle = SKFontStyle.Italic;
+                }
+                else if (excelFontXml.Bold)
+                {
+                    skFontStyle = SKFontStyle.Bold;
+                }
+
+                var fontTypeface = SKTypeface.FromFamilyName(excelFontXml.Name, skFontStyle);
+                if (fontTypeface.FamilyName == excelFontXml.Name)
+                {
+                    return new SKFont(fontTypeface, excelFontXml.Size);
+                }
+            }
+
+            return new SKFont(SKTypeface.Default);
         }
 
         private void SetMinWidth(double minimumWidth, int fromCol, int toCol)
@@ -933,8 +1028,10 @@ namespace OfficeOpenXml
                     newCol.ColumnMax = col.ColumnMin - 1;
                     newCol.Width = minimumWidth;
                 }
+
                 prevCol = col.ColumnMax + 1;
             }
+
             if (_worksheet.DefaultColWidth > minimumWidth && prevCol < toCol)
             {
                 var newCol = _worksheet.Column(prevCol);
@@ -945,11 +1042,9 @@ namespace OfficeOpenXml
 
         internal string TextForWidth
         {
-            get
-            {
-                return GetFormattedText(true);
-            }
+            get { return GetFormattedText(true); }
         }
+
         private string GetFormattedText(bool forWidthCalc)
         {
             object v = Value;
@@ -965,9 +1060,11 @@ namespace OfficeOpenXml
                     break;
                 }
             }
+
             if (nf == null)
             {
-                nf = styles.NumberFormats[0].FormatTranslator;  //nf should never be null. If so set to General, Issue 173
+                nf = styles.NumberFormats[0]
+                    .FormatTranslator; //nf should never be null. If so set to General, Issue 173
             }
 
             string format, textFormat;
@@ -985,7 +1082,8 @@ namespace OfficeOpenXml
             return FormatValue(v, nf, format, textFormat);
         }
 
-        internal static string FormatValue(object v, ExcelNumberFormatXml.ExcelFormatTranslator nf, string format, string textFormat)
+        internal static string FormatValue(object v, ExcelNumberFormatXml.ExcelFormatTranslator nf, string format,
+            string textFormat)
         {
             if (v is decimal || TypeCompat.IsPrimitive(v))
             {
@@ -1065,6 +1163,7 @@ namespace OfficeOpenXml
                     return string.Format(textFormat, v);
                 }
             }
+
             return v.ToString();
         }
 
@@ -1074,14 +1173,17 @@ namespace OfficeOpenXml
             {
                 return d.ToLongDateString();
             }
-            else if (nf.SpecialDateFormat == ExcelNumberFormatXml.ExcelFormatTranslator.eSystemDateFormat.SystemLongTime)
+            else if (nf.SpecialDateFormat ==
+                     ExcelNumberFormatXml.ExcelFormatTranslator.eSystemDateFormat.SystemLongTime)
             {
                 return d.ToLongTimeString();
             }
-            else if (nf.SpecialDateFormat == ExcelNumberFormatXml.ExcelFormatTranslator.eSystemDateFormat.SystemShortDate)
+            else if (nf.SpecialDateFormat ==
+                     ExcelNumberFormatXml.ExcelFormatTranslator.eSystemDateFormat.SystemShortDate)
             {
                 return d.ToShortDateString();
             }
+
             if (format == "d" || format == "D")
             {
                 return d.Day.ToString();
@@ -1106,7 +1208,6 @@ namespace OfficeOpenXml
             {
                 return d.ToString(format, nf.Culture);
             }
-
         }
 
         /// <summary>
@@ -1170,6 +1271,7 @@ namespace OfficeOpenXml
                 }
             }
         }
+
         /// <summary>
         /// Gets or Set a formula in R1C1 format.
         /// </summary>
@@ -1183,7 +1285,8 @@ namespace OfficeOpenXml
             set
             {
                 IsRangeValid("FormulaR1C1");
-                if (value.Length > 0 && value[0] == '=') value = value.Substring(1, value.Length - 1); // remove any starting equalsign.
+                if (value.Length > 0 && value[0] == '=')
+                    value = value.Substring(1, value.Length - 1); // remove any starting equalsign.
 
                 if (value == null || value.Trim() == "")
                 {
@@ -1196,14 +1299,18 @@ namespace OfficeOpenXml
                 }
                 else
                 {
-                    Set_SharedFormula(this, ExcelCellBase.TranslateFromR1C1(value, _fromRow, _fromCol), new ExcelAddress(WorkSheet, FirstAddress), false);
+                    Set_SharedFormula(this, ExcelCellBase.TranslateFromR1C1(value, _fromRow, _fromCol),
+                        new ExcelAddress(WorkSheet, FirstAddress), false);
                     foreach (var address in Addresses)
                     {
-                        Set_SharedFormula(this, ExcelCellBase.TranslateFromR1C1(value, address.Start.Row, address.Start.Column), address, false);
+                        Set_SharedFormula(this,
+                            ExcelCellBase.TranslateFromR1C1(value, address.Start.Row, address.Start.Column), address,
+                            false);
                     }
                 }
             }
         }
+
         /// <summary>
         /// Set the hyperlink property for a range of cells
         /// </summary>
@@ -1214,11 +1321,9 @@ namespace OfficeOpenXml
                 IsRangeValid("formulaR1C1");
                 return _worksheet._hyperLinks.GetValue(_fromRow, _fromCol);
             }
-            set
-            {
-                _changePropMethod(this, _setHyperLinkDelegate, value);
-            }
+            set { _changePropMethod(this, _setHyperLinkDelegate, value); }
         }
+
         /// <summary>
         /// If the cells in the range are merged.
         /// </summary>
@@ -1237,6 +1342,7 @@ namespace OfficeOpenXml
                         }
                     }
                 }
+
                 return true;
             }
             set
@@ -1261,13 +1367,14 @@ namespace OfficeOpenXml
                     {
                         foreach (var address in Addresses)
                         {
-                            _worksheet.MergedCells.Clear(address); ;
+                            _worksheet.MergedCells.Clear(address);
+                            ;
                         }
                     }
-
                 }
             }
         }
+
         /// <summary>
         /// Set an autofilter for the range
         /// </summary>
@@ -1279,15 +1386,16 @@ namespace OfficeOpenXml
                 ExcelAddressBase address = _worksheet.AutoFilterAddress;
                 if (address == null) return false;
                 if (_fromRow >= address.Start.Row
-                        &&
-                        _toRow <= address.End.Row
-                        &&
-                        _fromCol >= address.Start.Column
-                        &&
-                        _toCol <= address.End.Column)
+                    &&
+                    _toRow <= address.End.Row
+                    &&
+                    _fromCol >= address.Start.Column
+                    &&
+                    _toCol <= address.End.Column)
                 {
                     return true;
                 }
+
                 return false;
             }
             set
@@ -1298,13 +1406,16 @@ namespace OfficeOpenXml
                     var c = this.Collide(_worksheet.AutoFilterAddress);
                     if (value == false && (c == eAddressCollition.Partly || c == eAddressCollition.No))
                     {
-                        throw (new InvalidOperationException("Can't remote Autofilter. Current autofilter does not match selected range."));
+                        throw (new InvalidOperationException(
+                            "Can't remote Autofilter. Current autofilter does not match selected range."));
                     }
                 }
+
                 if (_worksheet.Names.ContainsKey("_xlnm._FilterDatabase"))
                 {
                     _worksheet.Names.Remove("_xlnm._FilterDatabase");
                 }
+
                 if (value)
                 {
                     _worksheet.AutoFilterAddress = this;
@@ -1317,6 +1428,7 @@ namespace OfficeOpenXml
                 }
             }
         }
+
         /// <summary>
         /// If the value is in richtext format.
         /// </summary>
@@ -1327,11 +1439,9 @@ namespace OfficeOpenXml
                 IsRangeValid("richtext");
                 return _worksheet._flags.GetFlagValue(_fromRow, _fromCol, CellFlags.RichText);
             }
-            set
-            {
-                _changePropMethod(this, _setIsRichTextDelegate, value);
-            }
+            set { _changePropMethod(this, _setIsRichTextDelegate, value); }
         }
+
         /// <summary>
         /// Is the range a part of an Arrayformula
         /// </summary>
@@ -1343,7 +1453,9 @@ namespace OfficeOpenXml
                 return _worksheet._flags.GetFlagValue(_fromRow, _fromCol, CellFlags.ArrayFormula);
             }
         }
+
         protected ExcelRichTextCollection _rtc = null;
+
         /// <summary>
         /// Cell value is richtext formatted. 
         /// Richtext-property only apply to the left-top cell of the range.
@@ -1357,6 +1469,7 @@ namespace OfficeOpenXml
                 {
                     _rtc = GetRichText(_fromRow, _fromCol);
                 }
+
                 return _rtc;
             }
         }
@@ -1370,20 +1483,27 @@ namespace OfficeOpenXml
             {
                 if (isRt)
                 {
-                    XmlHelper.LoadXmlSafe(xml, "<d:si xmlns:d=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" >" + v.ToString() + "</d:si>", Encoding.UTF8);
+                    XmlHelper.LoadXmlSafe(xml,
+                        "<d:si xmlns:d=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" >" + v.ToString() +
+                        "</d:si>", Encoding.UTF8);
                 }
                 else
                 {
-                    xml.LoadXml("<d:si xmlns:d=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" ><d:r><d:t>" + OfficeOpenXml.Utils.ConvertUtil.ExcelEscapeString(v.ToString()) + "</d:t></d:r></d:si>");
+                    xml.LoadXml(
+                        "<d:si xmlns:d=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" ><d:r><d:t>" +
+                        OfficeOpenXml.Utils.ConvertUtil.ExcelEscapeString(v.ToString()) + "</d:t></d:r></d:si>");
                 }
             }
             else
             {
                 xml.LoadXml("<d:si xmlns:d=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" />");
             }
-            var rtc = new ExcelRichTextCollection(_worksheet.NameSpaceManager, xml.SelectSingleNode("d:si", _worksheet.NameSpaceManager), this);
+
+            var rtc = new ExcelRichTextCollection(_worksheet.NameSpaceManager,
+                xml.SelectSingleNode("d:si", _worksheet.NameSpaceManager), this);
             return rtc;
         }
+
         /// <summary>
         /// returns the comment object of the first cell in the range
         /// </summary>
@@ -1400,19 +1520,19 @@ namespace OfficeOpenXml
                         return _worksheet._comments[i] as ExcelComment;
                     }
                 }
+
                 return null;
             }
         }
+
         /// <summary>
         /// WorkSheet object 
         /// </summary>
         public ExcelWorksheet Worksheet
         {
-            get
-            {
-                return _worksheet;
-            }
+            get { return _worksheet; }
         }
+
         /// <summary>
         /// Address including sheetname
         /// </summary>
@@ -1425,12 +1545,15 @@ namespace OfficeOpenXml
                 {
                     foreach (var a in Addresses)
                     {
-                        fullAddress += "," + GetFullAddress(_worksheet.Name, a.Address); ;
+                        fullAddress += "," + GetFullAddress(_worksheet.Name, a.Address);
+                        ;
                     }
                 }
+
                 return fullAddress;
             }
         }
+
         /// <summary>
         /// Address including sheetname
         /// </summary>
@@ -1438,7 +1561,9 @@ namespace OfficeOpenXml
         {
             get
             {
-                string wbwsRef = string.IsNullOrEmpty(base._wb) ? base._ws : "[" + base._wb.Replace("'", "''") + "]" + _ws;
+                string wbwsRef = string.IsNullOrEmpty(base._wb)
+                    ? base._ws
+                    : "[" + base._wb.Replace("'", "''") + "]" + _ws;
                 string fullAddress;
                 if (Addresses == null)
                 {
@@ -1456,13 +1581,16 @@ namespace OfficeOpenXml
                         }
                         else
                         {
-                            fullAddress += GetFullAddress(wbwsRef, GetAddress(a.Start.Row, a.Start.Column, a.End.Row, a.End.Column, true));
+                            fullAddress += GetFullAddress(wbwsRef,
+                                GetAddress(a.Start.Row, a.Start.Column, a.End.Row, a.End.Column, true));
                         }
                     }
                 }
+
                 return fullAddress;
             }
         }
+
         /// <summary>
         /// Address including sheetname
         /// </summary>
@@ -1470,7 +1598,9 @@ namespace OfficeOpenXml
         {
             get
             {
-                string wbwsRef = string.IsNullOrEmpty(base._wb) ? base._ws : "[" + base._wb.Replace("'", "''") + "]" + _ws;
+                string wbwsRef = string.IsNullOrEmpty(base._wb)
+                    ? base._ws
+                    : "[" + base._wb.Replace("'", "''") + "]" + _ws;
                 string fullAddress;
                 if (Addresses == null)
                 {
@@ -1482,21 +1612,29 @@ namespace OfficeOpenXml
                     foreach (var a in Addresses)
                     {
                         if (fullAddress != "") fullAddress += ",";
-                        fullAddress += GetFullAddress(wbwsRef, GetAddress(a.Start.Row, a.Start.Column, a.End.Row, a.End.Column, true), false); ;
+                        fullAddress += GetFullAddress(wbwsRef,
+                            GetAddress(a.Start.Row, a.Start.Column, a.End.Row, a.End.Column, true), false);
+                        ;
                     }
                 }
+
                 return fullAddress;
             }
         }
+
         #endregion
+
         #region Private Methods
+
         /// <summary>
         /// Set the value without altering the richtext property
         /// </summary>
         /// <param name="value">the value</param>
         internal void SetValueRichText(object value)
         {
-            if (_fromRow == 1 && _fromCol == 1 && _toRow == ExcelPackage.MaxRows && _toCol == ExcelPackage.MaxColumns)  //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
+            if (_fromRow == 1 && _fromCol == 1 && _toRow == ExcelPackage.MaxRows &&
+                _toCol == ExcelPackage
+                    .MaxColumns) //Full sheet (ex ws.Cells.Value=0). Set value for A1 only to avoid hanging 
             {
                 SetValue(value, 1, 1);
             }
@@ -1512,6 +1650,7 @@ namespace OfficeOpenXml
             // if (value is string) _worksheet._types.SetValue(row, col, "S"); else _worksheet._types.SetValue(row, col, "");
             _worksheet._formulas.SetValue(row, col, "");
         }
+
         internal void SetSharedFormulaID(int id)
         {
             for (int col = _fromCol; col <= _toCol; col++)
@@ -1522,6 +1661,7 @@ namespace OfficeOpenXml
                 }
             }
         }
+
         private void CheckAndSplitSharedFormula(ExcelAddressBase address)
         {
             for (int col = address._fromCol; col <= address._toCol; col++)
@@ -1552,10 +1692,13 @@ namespace OfficeOpenXml
                         if (id >= 0 && !formulas.Contains(id))
                         {
                             if (_worksheet._sharedFormulas[id].IsArray &&
-                                    Collide(_worksheet.Cells[_worksheet._sharedFormulas[id].Address]) == eAddressCollition.Partly) // If the formula is an array formula and its on the inside the overwriting range throw an exception
+                                Collide(_worksheet.Cells[_worksheet._sharedFormulas[id].Address]) ==
+                                eAddressCollition
+                                    .Partly) // If the formula is an array formula and its on the inside the overwriting range throw an exception
                             {
                                 throw (new InvalidOperationException("Can not overwrite a part of an array-formula"));
                             }
+
                             formulas.Add(id);
                         }
                     }
@@ -1584,8 +1727,14 @@ namespace OfficeOpenXml
                 return;
                 //fRange.SetSharedFormulaID(int.MinValue); 
             }
-            var firstCellCollide = address.Collide(new ExcelAddressBase(fRange._fromRow, fRange._fromCol, fRange._fromRow, fRange._fromCol));
-            if (collide == eAddressCollition.Partly && (firstCellCollide == eAddressCollition.Inside || firstCellCollide == eAddressCollition.Equal)) //Do we need to split? Only if the functions first row is inside the new range.
+
+            var firstCellCollide =
+                address.Collide(
+                    new ExcelAddressBase(fRange._fromRow, fRange._fromCol, fRange._fromRow, fRange._fromCol));
+            if (collide == eAddressCollition.Partly && (firstCellCollide == eAddressCollition.Inside ||
+                                                        firstCellCollide ==
+                                                        eAddressCollition
+                                                            .Equal)) //Do we need to split? Only if the functions first row is inside the new range.
             {
                 //The formula partly collides with the current range
                 bool fIsSet = false;
@@ -1596,6 +1745,7 @@ namespace OfficeOpenXml
                     f.Address = ExcelCellBase.GetAddress(fRange._fromRow, fRange._fromCol, _fromRow - 1, fRange._toCol);
                     fIsSet = true;
                 }
+
                 //Left Range
                 if (fRange._fromCol < address._fromCol)
                 {
@@ -1611,25 +1761,29 @@ namespace OfficeOpenXml
                     {
                         fIsSet = true;
                     }
+
                     if (fRange._fromRow < address._fromRow)
                         f.StartRow = address._fromRow;
                     else
                     {
                         f.StartRow = fRange._fromRow;
                     }
+
                     if (fRange._toRow < address._toRow)
                     {
                         f.Address = ExcelCellBase.GetAddress(f.StartRow, f.StartCol,
-                                fRange._toRow, address._fromCol - 1);
+                            fRange._toRow, address._fromCol - 1);
                     }
                     else
                     {
                         f.Address = ExcelCellBase.GetAddress(f.StartRow, f.StartCol,
-                             address._toRow, address._fromCol - 1);
+                            address._toRow, address._fromCol - 1);
                     }
+
                     f.Formula = TranslateFromR1C1(formulaR1C1, f.StartRow, f.StartCol);
                     _worksheet.Cells[f.Address].SetSharedFormulaID(f.Index);
                 }
+
                 //Right Range
                 if (fRange._toCol > address._toCol)
                 {
@@ -1644,6 +1798,7 @@ namespace OfficeOpenXml
                     {
                         fIsSet = true;
                     }
+
                     f.StartCol = address._toCol + 1;
                     if (address._fromRow < fRange._fromRow)
                         f.StartRow = fRange._fromRow;
@@ -1655,16 +1810,18 @@ namespace OfficeOpenXml
                     if (fRange._toRow < address._toRow)
                     {
                         f.Address = ExcelCellBase.GetAddress(f.StartRow, f.StartCol,
-                                fRange._toRow, fRange._toCol);
+                            fRange._toRow, fRange._toCol);
                     }
                     else
                     {
                         f.Address = ExcelCellBase.GetAddress(f.StartRow, f.StartCol,
-                                address._toRow, fRange._toCol);
+                            address._toRow, fRange._toCol);
                     }
+
                     f.Formula = TranslateFromR1C1(formulaR1C1, f.StartRow, f.StartCol);
                     _worksheet.Cells[f.Address].SetSharedFormulaID(f.Index);
                 }
+
                 //Bottom Range
                 if (fRange._toRow > address._toRow)
                 {
@@ -1682,19 +1839,21 @@ namespace OfficeOpenXml
                     f.Formula = TranslateFromR1C1(formulaR1C1, f.StartRow, f.StartCol);
 
                     f.Address = ExcelCellBase.GetAddress(f.StartRow, f.StartCol,
-                            fRange._toRow, fRange._toCol);
+                        fRange._toRow, fRange._toCol);
                     _worksheet.Cells[f.Address].SetSharedFormulaID(f.Index);
-
                 }
             }
         }
+
         private object ConvertData(ExcelTextFormat Format, string v, int col, bool isText)
         {
-            if (isText && (Format.DataTypes == null || Format.DataTypes.Length < col)) return string.IsNullOrEmpty(v) ? null : v;
+            if (isText && (Format.DataTypes == null || Format.DataTypes.Length < col))
+                return string.IsNullOrEmpty(v) ? null : v;
 
             double d;
             DateTime dt;
-            if (Format.DataTypes == null || Format.DataTypes.Length <= col || Format.DataTypes[col] == eDataTypes.Unknown)
+            if (Format.DataTypes == null || Format.DataTypes.Length <= col ||
+                Format.DataTypes[col] == eDataTypes.Unknown)
             {
                 string v2 = v.EndsWith("%") ? v.Substring(0, v.Length - 1) : v;
                 if (double.TryParse(v2, NumberStyles.Any, Format.Culture, out d))
@@ -1708,13 +1867,15 @@ namespace OfficeOpenXml
                         return d / 100;
                     }
                 }
+
                 if (DateTime.TryParse(v, Format.Culture, DateTimeStyles.None, out dt))
                 {
                     return dt;
                 }
                 else
                 {
-                    return string.IsNullOrEmpty(v) ? null : v; ;
+                    return string.IsNullOrEmpty(v) ? null : v;
+                    ;
                 }
             }
             else
@@ -1753,37 +1914,40 @@ namespace OfficeOpenXml
                         return v;
                     default:
                         return string.IsNullOrEmpty(v) ? null : v;
-
                 }
             }
         }
+
         #endregion
+
         #region Public Methods
+
         #region ConditionalFormatting
+
         /// <summary>
         /// Conditional Formatting for this range.
         /// </summary>
         public IRangeConditionalFormatting ConditionalFormatting
         {
-            get
-            {
-                return new RangeConditionalFormatting(_worksheet, new ExcelAddress(Address));
-            }
+            get { return new RangeConditionalFormatting(_worksheet, new ExcelAddress(Address)); }
         }
+
         #endregion
+
         #region DataValidation
+
         /// <summary>
         /// Data validation for this range.
         /// </summary>
         public IRangeDataValidation DataValidation
         {
-            get
-            {
-                return new RangeDataValidation(_worksheet, Address);
-            }
+            get { return new RangeDataValidation(_worksheet, Address); }
         }
+
         #endregion
+
         #region LoadFromDataReader
+
         /// <summary>
         /// Load the data from the datareader starting from the top left cell of the range
         /// </summary>
@@ -1792,17 +1956,21 @@ namespace OfficeOpenXml
         /// <param name="TableName">The name of the table</param>
         /// <param name="TableStyle">The table style to apply to the data</param>
         /// <returns>The filled range</returns>
-        public ExcelRangeBase LoadFromDataReader(IDataReader Reader, bool PrintHeaders, string TableName, TableStyles TableStyle = TableStyles.None)
+        public ExcelRangeBase LoadFromDataReader(IDataReader Reader, bool PrintHeaders, string TableName,
+            TableStyles TableStyle = TableStyles.None)
         {
             var r = LoadFromDataReader(Reader, PrintHeaders);
 
             int rows = r.Rows - 1;
             if (rows >= 0 && r.Columns > 0)
             {
-                var tbl = _worksheet.Tables.Add(new ExcelAddressBase(_fromRow, _fromCol, _fromRow + (rows <= 0 ? 1 : rows), _fromCol + r.Columns - 1), TableName);
+                var tbl = _worksheet.Tables.Add(
+                    new ExcelAddressBase(_fromRow, _fromCol, _fromRow + (rows <= 0 ? 1 : rows),
+                        _fromCol + r.Columns - 1), TableName);
                 tbl.ShowHeader = PrintHeaders;
                 tbl.TableStyle = TableStyle;
             }
+
             return r;
         }
 
@@ -1818,6 +1986,7 @@ namespace OfficeOpenXml
             {
                 throw (new ArgumentNullException("Reader", "Reader can't be null"));
             }
+
             int fieldCount = Reader.FieldCount;
 
             int col = _fromCol, row = _fromRow;
@@ -1828,23 +1997,29 @@ namespace OfficeOpenXml
                     // If no caption is set, the ColumnName property is called implicitly.
                     _worksheet.SetValueInner(row, col++, Reader.GetName(i));
                 }
+
                 row++;
                 col = _fromCol;
             }
+
             while (Reader.Read())
             {
                 for (int i = 0; i < fieldCount; i++)
                 {
                     _worksheet.SetValueInner(row, col++, Reader.GetValue(i));
                 }
+
                 row++;
                 col = _fromCol;
             }
+
             return _worksheet.Cells[_fromRow, _fromCol, row - 1, _fromCol + fieldCount - 1];
         }
+
         #endregion
 
         #region LoadFromDataTable
+
         /// <summary>
         /// Load the data from the datatable starting from the top left cell of the range
         /// </summary>
@@ -1859,12 +2034,16 @@ namespace OfficeOpenXml
             int rows = (Table.Rows.Count == 0 ? 1 : Table.Rows.Count) + (PrintHeaders ? 1 : 0);
             if (rows >= 0 && Table.Columns.Count > 0)
             {
-                var tbl = _worksheet.Tables.Add(new ExcelAddressBase(_fromRow, _fromCol, _fromRow + rows - 1, _fromCol + Table.Columns.Count - 1), Table.TableName);
+                var tbl = _worksheet.Tables.Add(
+                    new ExcelAddressBase(_fromRow, _fromCol, _fromRow + rows - 1, _fromCol + Table.Columns.Count - 1),
+                    Table.TableName);
                 tbl.ShowHeader = PrintHeaders;
                 tbl.TableStyle = TableStyle;
             }
+
             return r;
         }
+
         /// <summary>
         /// Load the data from the datatable starting from the top left cell of the range
         /// </summary>
@@ -1888,11 +2067,14 @@ namespace OfficeOpenXml
             {
                 rowArray.Add(Table.Columns.Cast<DataColumn>().Select((dc) => { return dc.Caption; }).ToArray());
             }
+
             foreach (DataRow dr in Table.Rows)
             {
                 rowArray.Add(dr.ItemArray);
             }
-            _worksheet._values.SetRangeValueSpecial(_fromRow, _fromCol, _fromRow + rowArray.Count - 1, _fromCol + Table.Columns.Count - 1,
+
+            _worksheet._values.SetRangeValueSpecial(_fromRow, _fromCol, _fromRow + rowArray.Count - 1,
+                _fromCol + Table.Columns.Count - 1,
                 (List<ExcelCoreValue> list, int index, int rowIx, int columnIx, object value) =>
                 {
                     rowIx -= _fromRow;
@@ -1905,11 +2087,14 @@ namespace OfficeOpenXml
                     }
                 }, rowArray);
 
-            return _worksheet.Cells[_fromRow, _fromCol, _fromRow + rowArray.Count - 1, _fromCol + Table.Columns.Count - 1];
+            return _worksheet.Cells[_fromRow, _fromCol, _fromRow + rowArray.Count - 1,
+                _fromCol + Table.Columns.Count - 1];
         }
+
         #endregion
 
         #region LoadFromArrays
+
         /// <summary>
         /// Loads data from the collection of arrays of objects into the range, starting from
         /// the top-left cell.
@@ -1927,8 +2112,10 @@ namespace OfficeOpenXml
                 rowArray.Add(item);
                 if (maxColumn < item.Length) maxColumn = item.Length;
             }
+
             if (rowArray.Count == 0) return null; //Issue #57
-            _worksheet._values.SetRangeValueSpecial(_fromRow, _fromCol, _fromRow + rowArray.Count - 1, _fromCol + maxColumn - 1,
+            _worksheet._values.SetRangeValueSpecial(_fromRow, _fromCol, _fromRow + rowArray.Count - 1,
+                _fromCol + maxColumn - 1,
                 (List<ExcelCoreValue> list, int index, int rowIx, int columnIx, object value) =>
                 {
                     rowIx -= _fromRow;
@@ -1948,8 +2135,11 @@ namespace OfficeOpenXml
 
             return _worksheet.Cells[_fromRow, _fromCol, _fromRow + rowArray.Count - 1, _fromCol + maxColumn - 1];
         }
+
         #endregion
+
         #region LoadFromCollection
+
         /// <summary>
         /// Load a collection into a the worksheet starting from the top left row of the range.
         /// </summary>
@@ -1958,8 +2148,10 @@ namespace OfficeOpenXml
         /// <returns>The filled range</returns>
         public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection)
         {
-            return LoadFromCollection<T>(Collection, false, TableStyles.None, BindingFlags.Public | BindingFlags.Instance, null);
+            return LoadFromCollection<T>(Collection, false, TableStyles.None,
+                BindingFlags.Public | BindingFlags.Instance, null);
         }
+
         /// <summary>
         /// Load a collection of T into the worksheet starting from the top left row of the range.
         /// Default option will load all public instance properties of T
@@ -1970,8 +2162,10 @@ namespace OfficeOpenXml
         /// <returns>The filled range</returns>
         public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders)
         {
-            return LoadFromCollection<T>(Collection, PrintHeaders, TableStyles.None, BindingFlags.Public | BindingFlags.Instance, null);
+            return LoadFromCollection<T>(Collection, PrintHeaders, TableStyles.None,
+                BindingFlags.Public | BindingFlags.Instance, null);
         }
+
         /// <summary>
         /// Load a collection of T into the worksheet starting from the top left row of the range.
         /// Default option will load all public instance properties of T
@@ -1981,10 +2175,13 @@ namespace OfficeOpenXml
         /// <param name="PrintHeaders">Print the property names on the first row. If the property is decorated with a <see cref="DisplayNameAttribute"/> or a <see cref="DescriptionAttribute"/> that attribute will be used instead of the reflected member name.</param>
         /// <param name="TableStyle">Will create a table with this style. If set to TableStyles.None no table will be created</param>
         /// <returns>The filled range</returns>
-        public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders, TableStyles TableStyle)
+        public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders,
+            TableStyles TableStyle)
         {
-            return LoadFromCollection<T>(Collection, PrintHeaders, TableStyle, BindingFlags.Public | BindingFlags.Instance, null);
+            return LoadFromCollection<T>(Collection, PrintHeaders, TableStyle,
+                BindingFlags.Public | BindingFlags.Instance, null);
         }
+
         /// <summary>
         /// Load a collection into the worksheet starting from the top left row of the range.
         /// </summary>
@@ -1995,7 +2192,8 @@ namespace OfficeOpenXml
         /// <param name="memberFlags">Property flags to use</param>
         /// <param name="Members">The properties to output. Must be of type T</param>
         /// <returns>The filled range</returns>
-        public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders, TableStyles TableStyle, BindingFlags memberFlags, MemberInfo[] Members)
+        public ExcelRangeBase LoadFromCollection<T>(IEnumerable<T> Collection, bool PrintHeaders,
+            TableStyles TableStyle, BindingFlags memberFlags, MemberInfo[] Members)
         {
             var type = typeof(T);
             bool isSameType = true;
@@ -2005,33 +2203,41 @@ namespace OfficeOpenXml
             }
             else
             {
-                if (Members.Length == 0)   //Fixes issue 15555
+                if (Members.Length == 0) //Fixes issue 15555
                 {
                     throw (new ArgumentException("Parameter Members must have at least one property. Length is zero"));
                 }
+
                 foreach (var t in Members)
                 {
                     if (t.DeclaringType != null && t.DeclaringType != type)
                     {
                         isSameType = false;
                     }
+
                     //Fixing inverted check for IsSubclassOf / Pullrequest from tomdam
-                    if (t.DeclaringType != null && t.DeclaringType != type && !TypeCompat.IsSubclassOf(type, t.DeclaringType) && !TypeCompat.IsSubclassOf(t.DeclaringType, type))
+                    if (t.DeclaringType != null && t.DeclaringType != type &&
+                        !TypeCompat.IsSubclassOf(type, t.DeclaringType) &&
+                        !TypeCompat.IsSubclassOf(t.DeclaringType, type))
                     {
-                        throw new InvalidCastException("Supplied properties in parameter Properties must be of the same type as T (or an assignable type from T)");
+                        throw new InvalidCastException(
+                            "Supplied properties in parameter Properties must be of the same type as T (or an assignable type from T)");
                     }
                 }
             }
 
             // create buffer
-            object[,] values = new object[(PrintHeaders ? Collection.Count() + 1 : Collection.Count()), Members.Count()];
+            object[,] values = new object[(PrintHeaders ? Collection.Count() + 1 : Collection.Count()),
+                Members.Count()];
 
             int col = 0, row = 0;
             if (Members.Length > 0 && PrintHeaders)
             {
                 foreach (var t in Members)
                 {
-                    var descriptionAttribute = t.GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault() as DescriptionAttribute;
+                    var descriptionAttribute =
+                        t.GetCustomAttributes(typeof(DescriptionAttribute), false).FirstOrDefault() as
+                            DescriptionAttribute;
                     var header = string.Empty;
                     if (descriptionAttribute != null)
                     {
@@ -2041,7 +2247,7 @@ namespace OfficeOpenXml
                     {
                         var displayNameAttribute =
                             t.GetCustomAttributes(typeof(DisplayNameAttribute), false).FirstOrDefault() as
-                            DisplayNameAttribute;
+                                DisplayNameAttribute;
                         if (displayNameAttribute != null)
                         {
                             header = displayNameAttribute.DisplayName;
@@ -2055,6 +2261,7 @@ namespace OfficeOpenXml
                     //_worksheet.SetValueInner(row, col++, header);
                     values[row, col++] = header;
                 }
+
                 row++;
             }
 
@@ -2093,6 +2300,7 @@ namespace OfficeOpenXml
                         }
                     }
                 }
+
                 row++;
             }
 
@@ -2112,10 +2320,14 @@ namespace OfficeOpenXml
                 tbl.ShowHeader = PrintHeaders;
                 tbl.TableStyle = TableStyle;
             }
+
             return r;
         }
+
         #endregion
+
         #region LoadFromText
+
         /// <summary>
         /// Loads a CSV text into a range starting from the top left cell.
         /// Default settings is Comma separation
@@ -2126,6 +2338,7 @@ namespace OfficeOpenXml
         {
             return LoadFromText(Text, new ExcelTextFormat());
         }
+
         /// <summary>
         /// Loads a CSV text into a range starting from the top left cell.
         /// </summary>
@@ -2181,6 +2394,7 @@ namespace OfficeOpenXml
                             {
                                 throw (new Exception(string.Format("Invalid Text Qualifier in line : {0}", line)));
                             }
+
                             isQualifier = !isQualifier;
                             QCount += 1;
                             lineQCount++;
@@ -2214,18 +2428,23 @@ namespace OfficeOpenXml
                                 {
                                     if (QCount % 2 == 1)
                                     {
-                                        throw (new Exception(string.Format("Text delimiter is not closed in line : {0}", line)));
+                                        throw (new Exception(string.Format("Text delimiter is not closed in line : {0}",
+                                            line)));
                                     }
+
                                     v += c;
                                 }
                             }
+
                             QCount = 0;
                         }
                     }
+
                     if (QCount > 1 && (v != "" && QCount == 2))
                     {
                         v += new string(Format.TextQualifier, QCount / 2);
                     }
+
                     if (lineQCount % 2 == 1)
                         throw (new Exception(string.Format("Text delimiter is not closed in line : {0}", line)));
 
@@ -2234,8 +2453,10 @@ namespace OfficeOpenXml
                     if (col > maxCol) maxCol = col;
                     row++;
                 }
+
                 lineNo++;
             }
+
             // flush
             _worksheet._values.SetRangeValueSpecial(_fromRow, _fromCol, _fromRow + values.Length - 1, _fromCol + maxCol,
                 (List<ExcelCoreValue> list, int index, int rowIx, int columnIx, object value) =>
@@ -2289,8 +2510,10 @@ namespace OfficeOpenXml
             {
                 list.Add(text.Substring(prevLineStart));
             }
+
             return list.ToArray();
         }
+
         private bool IsEOL(string text, int ix, string eol)
         {
             for (int i = 0; i < eol.Length; i++)
@@ -2298,6 +2521,7 @@ namespace OfficeOpenXml
                 if (text[ix + i] != eol[i])
                     return false;
             }
+
             return ix + eol.Length <= text.Length;
         }
 
@@ -2309,7 +2533,8 @@ namespace OfficeOpenXml
         /// <param name="TableStyle">Create a table with this style</param>
         /// <param name="FirstRowIsHeader">Use the first row as header</param>
         /// <returns></returns>
-        public ExcelRangeBase LoadFromText(string Text, ExcelTextFormat Format, TableStyles TableStyle, bool FirstRowIsHeader)
+        public ExcelRangeBase LoadFromText(string Text, ExcelTextFormat Format, TableStyles TableStyle,
+            bool FirstRowIsHeader)
         {
             var r = LoadFromText(Text, Format);
 
@@ -2319,6 +2544,7 @@ namespace OfficeOpenXml
 
             return r;
         }
+
         /// <summary>
         /// Loads a CSV file into a range starting from the top left cell.
         /// </summary>
@@ -2328,6 +2554,7 @@ namespace OfficeOpenXml
         {
             return LoadFromText(File.ReadAllText(TextFile.FullName, Encoding.ASCII));
         }
+
         /// <summary>
         /// Loads a CSV file into a range starting from the top left cell.
         /// </summary>
@@ -2338,6 +2565,7 @@ namespace OfficeOpenXml
         {
             return LoadFromText(File.ReadAllText(TextFile.FullName, Format.Encoding), Format);
         }
+
         /// <summary>
         /// Loads a CSV file into a range starting from the top left cell.
         /// </summary>
@@ -2346,11 +2574,15 @@ namespace OfficeOpenXml
         /// <param name="TableStyle">Create a table with this style</param>
         /// <param name="FirstRowIsHeader">Use the first row as header</param>
         /// <returns></returns>
-        public ExcelRangeBase LoadFromText(FileInfo TextFile, ExcelTextFormat Format, TableStyles TableStyle, bool FirstRowIsHeader)
+        public ExcelRangeBase LoadFromText(FileInfo TextFile, ExcelTextFormat Format, TableStyles TableStyle,
+            bool FirstRowIsHeader)
         {
-            return LoadFromText(File.ReadAllText(TextFile.FullName, Format.Encoding), Format, TableStyle, FirstRowIsHeader);
+            return LoadFromText(File.ReadAllText(TextFile.FullName, Format.Encoding), Format, TableStyle,
+                FirstRowIsHeader);
         }
+
         #endregion
+
         #region GetValue
 
         /// <summary>
@@ -2380,7 +2612,9 @@ namespace OfficeOpenXml
         {
             return ConvertUtil.GetTypedCellValue<T>(Value);
         }
+
         #endregion
+
         /// <summary>
         /// Get a range with an offset from the top left cell.
         /// The new range has the same dimensions as the current range
@@ -2390,13 +2624,17 @@ namespace OfficeOpenXml
         /// <returns></returns>
         public ExcelRangeBase Offset(int RowOffset, int ColumnOffset)
         {
-            if (_fromRow + RowOffset < 1 || _fromCol + ColumnOffset < 1 || _fromRow + RowOffset > ExcelPackage.MaxRows || _fromCol + ColumnOffset > ExcelPackage.MaxColumns)
+            if (_fromRow + RowOffset < 1 || _fromCol + ColumnOffset < 1 ||
+                _fromRow + RowOffset > ExcelPackage.MaxRows || _fromCol + ColumnOffset > ExcelPackage.MaxColumns)
             {
                 throw (new ArgumentOutOfRangeException("Offset value out of range"));
             }
-            string address = GetAddress(_fromRow + RowOffset, _fromCol + ColumnOffset, _toRow + RowOffset, _toCol + ColumnOffset);
+
+            string address = GetAddress(_fromRow + RowOffset, _fromCol + ColumnOffset, _toRow + RowOffset,
+                _toCol + ColumnOffset);
             return new ExcelRangeBase(_worksheet, address);
         }
+
         /// <summary>
         /// Get a range with an offset from the top left cell.
         /// </summary>
@@ -2411,16 +2649,23 @@ namespace OfficeOpenXml
             {
                 throw (new Exception("Number of rows/columns must be greater than 0"));
             }
+
             NumberOfRows--;
             NumberOfColumns--;
-            if (_fromRow + RowOffset < 1 || _fromCol + ColumnOffset < 1 || _fromRow + RowOffset > ExcelPackage.MaxRows || _fromCol + ColumnOffset > ExcelPackage.MaxColumns ||
-                 _fromRow + RowOffset + NumberOfRows < 1 || _fromCol + ColumnOffset + NumberOfColumns < 1 || _fromRow + RowOffset + NumberOfRows > ExcelPackage.MaxRows || _fromCol + ColumnOffset + NumberOfColumns > ExcelPackage.MaxColumns)
+            if (_fromRow + RowOffset < 1 || _fromCol + ColumnOffset < 1 ||
+                _fromRow + RowOffset > ExcelPackage.MaxRows || _fromCol + ColumnOffset > ExcelPackage.MaxColumns ||
+                _fromRow + RowOffset + NumberOfRows < 1 || _fromCol + ColumnOffset + NumberOfColumns < 1 ||
+                _fromRow + RowOffset + NumberOfRows > ExcelPackage.MaxRows ||
+                _fromCol + ColumnOffset + NumberOfColumns > ExcelPackage.MaxColumns)
             {
                 throw (new ArgumentOutOfRangeException("Offset value out of range"));
             }
-            string address = GetAddress(_fromRow + RowOffset, _fromCol + ColumnOffset, _fromRow + RowOffset + NumberOfRows, _fromCol + ColumnOffset + NumberOfColumns);
+
+            string address = GetAddress(_fromRow + RowOffset, _fromCol + ColumnOffset,
+                _fromRow + RowOffset + NumberOfRows, _fromCol + ColumnOffset + NumberOfColumns);
             return new ExcelRangeBase(_worksheet, address);
         }
+
         /// <summary>
         /// Adds a new comment for the range.
         /// If this range contains more than one cell, the top left comment is returned by the method.
@@ -2438,6 +2683,7 @@ namespace OfficeOpenXml
                 Author = Thread.CurrentPrincipal.Identity.Name;
 #endif
             }
+
             //Check if any comments exists in the range and throw an exception
             _changePropMethod(this, _setExistsCommentDelegate, null);
             //Create the comments
@@ -2464,7 +2710,7 @@ namespace OfficeOpenXml
         {
             bool sameWorkbook = Destination._worksheet.Workbook == _worksheet.Workbook;
             ExcelStyles sourceStyles = _worksheet.Workbook.Styles,
-                        styles = Destination._worksheet.Workbook.Styles;
+                styles = Destination._worksheet.Workbook.Styles;
             Dictionary<int, int> styleCashe = new Dictionary<int, int>();
 
             //Clear all existing cells; 
@@ -2476,14 +2722,16 @@ namespace OfficeOpenXml
             byte flag = 0;
             Uri hl = null;
 
-            var excludeFormulas = excelRangeCopyOptionFlags.HasValue && (excelRangeCopyOptionFlags.Value & ExcelRangeCopyOptionFlags.ExcludeFormulas) == ExcelRangeCopyOptionFlags.ExcludeFormulas;
+            var excludeFormulas = excelRangeCopyOptionFlags.HasValue &&
+                                  (excelRangeCopyOptionFlags.Value & ExcelRangeCopyOptionFlags.ExcludeFormulas) ==
+                                  ExcelRangeCopyOptionFlags.ExcludeFormulas;
             var cse = new CellsStoreEnumerator<ExcelCoreValue>(_worksheet._values, _fromRow, _fromCol, _toRow, _toCol);
 
             var copiedValue = new List<CopiedCell>();
             while (cse.Next())
             {
                 var row = cse.Row;
-                var col = cse.Column;       //Issue 15070
+                var col = cse.Column; //Issue 15070
                 var cell = new CopiedCell
                 {
                     Row = Destination._fromRow + (row - _fromRow),
@@ -2498,7 +2746,8 @@ namespace OfficeOpenXml
                         cell.Formula = _worksheet.GetFormula(cse.Row, cse.Column);
                         if (_worksheet._flags.GetFlagValue(cse.Row, cse.Column, CellFlags.ArrayFormula))
                         {
-                            Destination._worksheet._flags.SetFlagValue(cse.Row, cse.Column, true, CellFlags.ArrayFormula);
+                            Destination._worksheet._flags.SetFlagValue(cse.Row, cse.Column, true,
+                                CellFlags.ArrayFormula);
                         }
                     }
                     else
@@ -2506,6 +2755,7 @@ namespace OfficeOpenXml
                         cell.Formula = o;
                     }
                 }
+
                 if (_worksheet.ExistsStyleInner(row, col, ref i))
                 {
                     if (sameWorkbook)
@@ -2524,6 +2774,7 @@ namespace OfficeOpenXml
                             i = styles.CloneStyle(sourceStyles, i);
                             styleCashe.Add(oldStyleID, i);
                         }
+
                         cell.StyleID = i;
                     }
                 }
@@ -2540,6 +2791,7 @@ namespace OfficeOpenXml
                 {
                     cell.Flag = flag;
                 }
+
                 copiedValue.Add(cell);
             }
 
@@ -2575,11 +2827,14 @@ namespace OfficeOpenXml
                             i = styles.CloneStyle(sourceStyles, i);
                             styleCashe.Add(oldStyleID, i);
                         }
+
                         cell.StyleID = i;
                     }
+
                     copiedValue.Add(cell);
                 }
             }
+
             var copiedMergedCells = new Dictionary<int, ExcelAddress>();
             //Merged cells
             var csem = new CellsStoreEnumerator<int>(_worksheet.MergedCells._cells, _fromRow, _fromCol, _toRow, _toCol);
@@ -2605,7 +2860,8 @@ namespace OfficeOpenXml
                 }
             }
 
-            Destination._worksheet.MergedCells.Clear(new ExcelAddressBase(Destination._fromRow, Destination._fromCol, Destination._fromRow + toRow - 1, Destination._fromCol + toCol - 1));
+            Destination._worksheet.MergedCells.Clear(new ExcelAddressBase(Destination._fromRow, Destination._fromCol,
+                Destination._fromRow + toRow - 1, Destination._fromCol + toCol - 1));
 
             Destination._worksheet._values.Clear(Destination._fromRow, Destination._fromCol, toRow, toCol);
             Destination._worksheet._formulas.Clear(Destination._fromRow, Destination._fromCol, toRow, toCol);
@@ -2624,9 +2880,11 @@ namespace OfficeOpenXml
 
                 if (cell.Formula != null)
                 {
-                    cell.Formula = UpdateFormulaReferences(cell.Formula.ToString(), Destination._fromRow - _fromRow, Destination._fromCol - _fromCol, 0, 0, Destination.WorkSheet, Destination.WorkSheet, true);
+                    cell.Formula = UpdateFormulaReferences(cell.Formula.ToString(), Destination._fromRow - _fromRow,
+                        Destination._fromCol - _fromCol, 0, 0, Destination.WorkSheet, Destination.WorkSheet, true);
                     Destination._worksheet._formulas.SetValue(cell.Row, cell.Column, cell.Formula);
                 }
+
                 if (cell.HyperLink != null)
                 {
                     Destination._worksheet._hyperLinks.SetValue(cell.Row, cell.Column, cell.HyperLink);
@@ -2634,8 +2892,10 @@ namespace OfficeOpenXml
 
                 if (cell.Comment != null)
                 {
-                    Destination.Worksheet.Cells[cell.Row, cell.Column].AddComment(cell.Comment.Text, cell.Comment.Author);
+                    Destination.Worksheet.Cells[cell.Row, cell.Column]
+                        .AddComment(cell.Comment.Text, cell.Comment.Author);
                 }
+
                 if (cell.Flag != 0)
                 {
                     Destination._worksheet._flags.SetValue(cell.Row, cell.Column, cell.Flag);
@@ -2680,6 +2940,7 @@ namespace OfficeOpenXml
                     destinationRow.OutlineLevel = Worksheet.Row(range._fromRow + r).OutlineLevel;
                 }
             }
+
             if (_fromRow == 1 && _toRow == ExcelPackage.MaxRows)
             {
                 for (int c = 0; c < range.Columns; c++)
@@ -2697,6 +2958,7 @@ namespace OfficeOpenXml
         {
             Delete(this, false);
         }
+
         /// <summary>
         /// Creates an array-formula.
         /// </summary>
@@ -2707,8 +2969,10 @@ namespace OfficeOpenXml
             {
                 throw (new Exception("An Arrayformula can not have more than one address"));
             }
+
             Set_SharedFormula(this, ArrayFormula, this, true);
         }
+
         //private void Clear(ExcelAddressBase Range)
         //{
         //    Clear(Range, true);
@@ -2728,6 +2992,7 @@ namespace OfficeOpenXml
             {
                 fromRow = Range._fromRow;
             }
+
             if (d != null && Range._fromCol <= d._fromCol && Range._toCol >= d._toCol) //EntireRow?
             {
                 fromCol = 0;
@@ -2776,12 +3041,15 @@ namespace OfficeOpenXml
                     }
                 }
             }
+
             foreach (var item in removeItems)
             {
                 Worksheet.MergedCells.Remove(item);
             }
         }
+
         #endregion
+
         #region IDisposable Members
 
         public void Dispose()
@@ -2790,8 +3058,11 @@ namespace OfficeOpenXml
         }
 
         #endregion
+
         #region "Enumerator"
+
         CellsStoreEnumerator<ExcelCoreValue> cellEnum;
+
         public IEnumerator<ExcelRangeBase> GetEnumerator()
         {
             Reset();
@@ -2809,10 +3080,7 @@ namespace OfficeOpenXml
         /// </summary>
         public ExcelRangeBase Current
         {
-            get
-            {
-                return new ExcelRangeBase(_worksheet, ExcelAddressBase.GetAddress(cellEnum.Row, cellEnum.Column));
-            }
+            get { return new ExcelRangeBase(_worksheet, ExcelAddressBase.GetAddress(cellEnum.Row, cellEnum.Column)); }
         }
 
         /// <summary>
@@ -2822,13 +3090,15 @@ namespace OfficeOpenXml
         {
             get
             {
-                return ((object)(new ExcelRangeBase(_worksheet, ExcelAddressBase.GetAddress(cellEnum.Row, cellEnum.Column))));
+                return ((object)(new ExcelRangeBase(_worksheet,
+                    ExcelAddressBase.GetAddress(cellEnum.Row, cellEnum.Column))));
             }
         }
 
         //public object FormatedText { get; private set; }
 
         int _enumAddressIx = -1;
+
         public bool MoveNext()
         {
             if (cellEnum.Next())
@@ -2852,6 +3122,7 @@ namespace OfficeOpenXml
                     return false;
                 }
             }
+
             return false;
         }
 
@@ -2860,18 +3131,22 @@ namespace OfficeOpenXml
             _enumAddressIx = -1;
             cellEnum = new CellsStoreEnumerator<ExcelCoreValue>(_worksheet._values, _fromRow, _fromCol, _toRow, _toCol);
         }
+
         #endregion
+
         private struct SortItem<T>
         {
             internal int Row { get; set; }
             internal T[] Items { get; set; }
         }
+
         private class Comp : IComparer<SortItem<ExcelCoreValue>>
         {
             public int[] columns;
             public bool[] descending;
             public CultureInfo cultureInfo = CultureInfo.CurrentCulture;
             public CompareOptions compareOptions = CompareOptions.None;
+
             public int Compare(SortItem<ExcelCoreValue> x, SortItem<ExcelCoreValue> y)
             {
                 var ret = 0;
@@ -2881,7 +3156,7 @@ namespace OfficeOpenXml
                     var y1 = y.Items[columns[i]]._value;
                     var isNumX = ConvertUtil.IsNumeric(x1);
                     var isNumY = ConvertUtil.IsNumeric(y1);
-                    if (isNumX && isNumY)   //Numeric Compare
+                    if (isNumX && isNumY) //Numeric Compare
                     {
                         var d1 = ConvertUtil.GetValueDouble(x1);
                         var d2 = ConvertUtil.GetValueDouble(y1);
@@ -2889,13 +3164,15 @@ namespace OfficeOpenXml
                         {
                             d1 = double.MaxValue;
                         }
+
                         if (double.IsNaN(d2))
                         {
                             d2 = double.MaxValue;
                         }
+
                         ret = d1 < d2 ? -1 : (d1 > d2 ? 1 : 0);
                     }
-                    else if (isNumX == false && isNumY == false)   //String Compare
+                    else if (isNumX == false && isNumY == false) //String Compare
                     {
                         var s1 = x1 == null ? "" : x1.ToString();
                         var s2 = y1 == null ? "" : y1.ToString();
@@ -2905,11 +3182,14 @@ namespace OfficeOpenXml
                     {
                         ret = isNumX ? -1 : 1;
                     }
+
                     if (ret != 0) return ret * (descending[i] ? -1 : 1);
                 }
+
                 return 0;
             }
         }
+
         /// <summary>
         /// Sort the range by value of the first column, Ascending.
         /// </summary>
@@ -2917,6 +3197,7 @@ namespace OfficeOpenXml
         {
             Sort(new int[] { 0 }, new bool[] { false });
         }
+
         /// <summary>
         /// Sort the range by value of the supplied column, Ascending.
         /// <param name="column">The column to sort by within the range. Zerobased</param>
@@ -2926,6 +3207,7 @@ namespace OfficeOpenXml
         {
             Sort(new int[] { column }, new bool[] { descending });
         }
+
         /// <summary>
         /// Sort the range by value
         /// </summary>
@@ -2933,20 +3215,24 @@ namespace OfficeOpenXml
         /// <param name="descending">Descending if true, otherwise Ascending. Default Ascending. Zerobased</param>
         /// <param name="culture">The CultureInfo used to compare values. A null value means CurrentCulture</param>
         /// <param name="compareOptions">String compare option</param>
-        public void Sort(int[] columns, bool[] descending = null, CultureInfo culture = null, CompareOptions compareOptions = CompareOptions.None)
+        public void Sort(int[] columns, bool[] descending = null, CultureInfo culture = null,
+            CompareOptions compareOptions = CompareOptions.None)
         {
             if (columns == null)
             {
                 columns = new int[] { 0 };
             }
+
             var cols = _toCol - _fromCol + 1;
             foreach (var c in columns)
             {
                 if (c > cols - 1 || c < 0)
                 {
-                    throw (new ArgumentException("Can not reference columns outside the boundries of the range. Note that column reference is zero-based within the range"));
+                    throw (new ArgumentException(
+                        "Can not reference columns outside the boundries of the range. Note that column reference is zero-based within the range"));
                 }
             }
+
             var e = new CellsStoreEnumerator<ExcelCoreValue>(_worksheet._values, _fromRow, _fromCol, _toRow, _toCol);
             var l = new List<SortItem<ExcelCoreValue>>();
             SortItem<ExcelCoreValue> item = new SortItem<ExcelCoreValue>();
@@ -2958,6 +3244,7 @@ namespace OfficeOpenXml
                     item = new SortItem<ExcelCoreValue>() { Row = e.Row, Items = new ExcelCoreValue[cols] };
                     l.Add(item);
                 }
+
                 item.Items[e.Column - _fromCol] = e.Value;
             }
 
@@ -2996,6 +3283,7 @@ namespace OfficeOpenXml
                     {
                         _worksheet._flags.SetValue(row, col, flags[addr]);
                     }
+
                     //Move formulas
                     if (formulas.ContainsKey(addr))
                     {
@@ -3007,13 +3295,16 @@ namespace OfficeOpenXml
                             var f = Worksheet._sharedFormulas[sfIx];
                             if (startAddr._fromRow > row)
                             {
-                                f.Formula = ExcelCellBase.TranslateFromR1C1(ExcelCellBase.TranslateToR1C1(f.Formula, f.StartRow, f.StartCol), row, f.StartCol);
+                                f.Formula = ExcelCellBase.TranslateFromR1C1(
+                                    ExcelCellBase.TranslateToR1C1(f.Formula, f.StartRow, f.StartCol), row, f.StartCol);
                                 f.StartRow = row;
-                                f.Address = ExcelCellBase.GetAddress(row, startAddr._fromCol, startAddr._toRow, startAddr._toCol);
+                                f.Address = ExcelCellBase.GetAddress(row, startAddr._fromCol, startAddr._toRow,
+                                    startAddr._toCol);
                             }
                             else if (startAddr._toRow < row)
                             {
-                                f.Address = ExcelCellBase.GetAddress(startAddr._fromRow, startAddr._fromCol, row, startAddr._toCol);
+                                f.Address = ExcelCellBase.GetAddress(startAddr._fromRow, startAddr._fromCol, row,
+                                    startAddr._toCol);
                             }
                         }
                     }
@@ -3036,7 +3327,8 @@ namespace OfficeOpenXml
             }
         }
 
-        private static Dictionary<string, T> GetItems<T>(CellStore<T> store, int fromRow, int fromCol, int toRow, int toCol)
+        private static Dictionary<string, T> GetItems<T>(CellStore<T> store, int fromRow, int fromCol, int toRow,
+            int toCol)
         {
             var e = new CellsStoreEnumerator<T>(store, fromRow, fromCol, toRow, toCol);
             var l = new Dictionary<string, T>();
@@ -3044,6 +3336,7 @@ namespace OfficeOpenXml
             {
                 l.Add(e.CellAddress, e.Value);
             }
+
             return l;
         }
 

--- a/src/EPPlus/EPPlus/ExcelWorkbook.cs
+++ b/src/EPPlus/EPPlus/ExcelWorkbook.cs
@@ -653,7 +653,11 @@ namespace OfficeOpenXml
 
                         StringBuilder xml = new StringBuilder("<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");
                         xml.Append("<numFmts />");
-                        xml.Append("<fonts count=\"1\"><font><sz val=\"11\" /><name val=\"Calibri\" /></font></fonts>");
+                        xml.Append("<fonts count=\"2\">");
+                        xml.Append("<font><sz val=\"11\" /><name val=\"Calibri\" /></font>");
+                        xml.Append("<font><sz val=\"11\" /><name val=\"FangSong\" /></font>"); 
+                        // As the System.Drawing.Graphics is a GDI+, no matter SixLabors or SkiaSharp, always give inconsistent text measuring result in Calibri font. Use a FangSong instead.
+                        xml.Append("</fonts>");
                         xml.Append("<fills><fill><patternFill patternType=\"none\" /></fill><fill><patternFill patternType=\"gray125\" /></fill></fills>");
                         xml.Append("<borders><border><left /><right /><top /><bottom /><diagonal /></border></borders>");
                         xml.Append("<cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" /></cellStyleXfs>");

--- a/src/EPPlus/EPPlus/Magicodes.IE.EPPlus.csproj
+++ b/src/EPPlus/EPPlus/Magicodes.IE.EPPlus.csproj
@@ -68,6 +68,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.1.1" />
-		<PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta18" />
+		<PackageReference Include="SkiaSharp" Version="2.88.3" />
 	</ItemGroup>
 </Project>

--- a/src/EPPlus/EPPlus/Style/ExcelFont.cs
+++ b/src/EPPlus/EPPlus/Style/ExcelFont.cs
@@ -31,8 +31,7 @@
  *******************************************************************************/
 
 using System;
-using SixLabors.ImageSharp;
-using SixLabors.Fonts;
+using SkiaSharp;
 
 namespace OfficeOpenXml.Style
 {
@@ -207,15 +206,15 @@ namespace OfficeOpenXml.Style
         /// <summary>
         /// Set the font from a Font object
         /// </summary>
-        /// <param name="textRun"></param>
-        public void SetFromTextRun(TextRun textRun)
+        /// <param name="font"></param>
+        public void SetFromFont(SKFont font)
         {
-            var font = textRun.Font;
+            Name = font.Typeface.FamilyName;
             Size = font.Size;
-            Bold = font.IsBold;
-            Italic = font.IsItalic;
-            UnderLine = (textRun.TextDecorations & TextDecorations.Underline) != 0;
-            Strike = (textRun.TextDecorations & TextDecorations.Strikeout) != 0;
+            Bold = font.Typeface.IsBold;
+            Italic = font.Typeface.IsItalic;
+            UnderLine = font.Metrics.UnderlineThickness != null;
+            Strike = font.Metrics.StrikeoutThickness != null;
         }
 
         internal override string Id

--- a/src/EPPlus/EPPlus/Style/ExcelTextFont.cs
+++ b/src/EPPlus/EPPlus/Style/ExcelTextFont.cs
@@ -29,13 +29,14 @@
  * Jan Källman		                Initial Release		        2009-10-01
  * Jan Källman		License changed GPL-->LGPL 2011-12-16
  *******************************************************************************/
+
 using System;
 using SixLabors.ImageSharp;
 using System.Globalization;
 using System.Xml;
 using Magicodes.IE.EPPlus.SixLabors;
-using SixLabors.Fonts;
 using SixLabors.ImageSharp.PixelFormats;
+using SkiaSharp;
 
 namespace OfficeOpenXml.Style
 {
@@ -63,6 +64,7 @@ namespace OfficeOpenXml.Style
         WavyHeavy,
         Words
     }
+
     /// <summary>
     /// Type of font strike
     /// </summary>
@@ -72,6 +74,7 @@ namespace OfficeOpenXml.Style
         No,
         Single
     }
+
     /// <summary>
     /// Used by Rich-text and Paragraphs.
     /// </summary>
@@ -79,7 +82,9 @@ namespace OfficeOpenXml.Style
     {
         string _path;
         XmlNode _rootNode;
-        internal ExcelTextFont(XmlNamespaceManager namespaceManager, XmlNode rootNode, string path, string[] schemaNodeOrder)
+
+        internal ExcelTextFont(XmlNamespaceManager namespaceManager, XmlNode rootNode, string path,
+            string[] schemaNodeOrder)
             : base(namespaceManager, rootNode)
         {
             SchemaNodeOrder = schemaNodeOrder;
@@ -92,15 +97,15 @@ namespace OfficeOpenXml.Style
                     TopNode = node;
                 }
             }
+
             _path = path;
         }
+
         string _fontLatinPath = "a:latin/@typeface";
+
         public string LatinFont
         {
-            get
-            {
-                return GetXmlNodeString(_fontLatinPath);
-            }
+            get { return GetXmlNodeString(_fontLatinPath); }
             set
             {
                 CreateTopNode();
@@ -116,46 +121,45 @@ namespace OfficeOpenXml.Style
                 TopNode = _rootNode.SelectSingleNode(_path, NameSpaceManager);
             }
         }
+
         string _fontCsPath = "a:cs/@typeface";
+
         public string ComplexFont
         {
-            get
-            {
-                return GetXmlNodeString(_fontCsPath);
-            }
+            get { return GetXmlNodeString(_fontCsPath); }
             set
             {
                 CreateTopNode();
                 SetXmlNodeString(_fontCsPath, value);
             }
         }
+
         string _boldPath = "@b";
+
         public bool Bold
         {
-            get
-            {
-                return GetXmlNodeBool(_boldPath);
-            }
+            get { return GetXmlNodeBool(_boldPath); }
             set
             {
                 CreateTopNode();
                 SetXmlNodeString(_boldPath, value ? "1" : "0");
             }
         }
+
         string _underLinePath = "@u";
+
         public eUnderLineType UnderLine
         {
-            get
-            {
-                return TranslateUnderline(GetXmlNodeString(_underLinePath));
-            }
+            get { return TranslateUnderline(GetXmlNodeString(_underLinePath)); }
             set
             {
                 CreateTopNode();
                 SetXmlNodeString(_underLinePath, TranslateUnderlineText(value));
             }
         }
+
         string _underLineColorPath = "a:uFill/a:solidFill/a:srgbClr/@val";
+
         public Color UnderLineColor
         {
             get
@@ -174,49 +178,48 @@ namespace OfficeOpenXml.Style
             set
             {
                 CreateTopNode();
-                SetXmlNodeString(_underLineColorPath, value.ToArgbHex()/*.Substring(2)*/);
+                SetXmlNodeString(_underLineColorPath, value.ToArgbHex() /*.Substring(2)*/);
             }
         }
+
         string _italicPath = "@i";
+
         public bool Italic
         {
-            get
-            {
-                return GetXmlNodeBool(_italicPath);
-            }
+            get { return GetXmlNodeBool(_italicPath); }
             set
             {
                 CreateTopNode();
                 SetXmlNodeString(_italicPath, value ? "1" : "0");
             }
         }
+
         string _strikePath = "@strike";
+
         public eStrikeType Strike
         {
-            get
-            {
-                return TranslateStrike(GetXmlNodeString(_strikePath));
-            }
+            get { return TranslateStrike(GetXmlNodeString(_strikePath)); }
             set
             {
                 CreateTopNode();
                 SetXmlNodeString(_strikePath, TranslateStrikeText(value));
             }
         }
+
         string _sizePath = "@sz";
+
         public float Size
         {
-            get
-            {
-                return GetXmlNodeInt(_sizePath) / 100;
-            }
+            get { return GetXmlNodeInt(_sizePath) / 100; }
             set
             {
                 CreateTopNode();
                 SetXmlNodeString(_sizePath, ((int)(value * 100)).ToString());
             }
         }
+
         string _colorPath = "a:solidFill/a:srgbClr/@val";
+
         public Color Color
         {
             get
@@ -235,10 +238,12 @@ namespace OfficeOpenXml.Style
             set
             {
                 CreateTopNode();
-                SetXmlNodeString(_colorPath, value.ToArgbHex()/*.Substring(2)*/);
+                SetXmlNodeString(_colorPath, value.ToArgbHex() /*.Substring(2)*/);
             }
         }
+
         #region "Translate methods"
+
         private eUnderLineType TranslateUnderline(string text)
         {
             switch (text)
@@ -253,6 +258,7 @@ namespace OfficeOpenXml.Style
                     return (eUnderLineType)Enum.Parse(typeof(eUnderLineType), text);
             }
         }
+
         private string TranslateUnderlineText(eUnderLineType value)
         {
             switch (value)
@@ -266,6 +272,7 @@ namespace OfficeOpenXml.Style
                     return ret.Substring(0, 1).ToLower(CultureInfo.InvariantCulture) + ret.Substring(1, ret.Length - 1);
             }
         }
+
         private eStrikeType TranslateStrike(string text)
         {
             switch (text)
@@ -278,6 +285,7 @@ namespace OfficeOpenXml.Style
                     return eStrikeType.No;
             }
         }
+
         private string TranslateStrikeText(eStrikeType value)
         {
             switch (value)
@@ -290,21 +298,22 @@ namespace OfficeOpenXml.Style
                     return "noStrike";
             }
         }
+
         #endregion
+
         /// <summary>
-        /// Set the font style from a textRun object
+        /// Set the font style from a font object
         /// </summary>
-        /// <param name="textRun"></param>
-        public void SetFromTextRun(TextRun textRun)
+        /// <param name="font"></param>
+        public void SetFromFont(SKFont font)
         {
-            var font = textRun.Font;
-            LatinFont = font.Name;
-            ComplexFont = font.Name;
+            LatinFont = font.Typeface.FamilyName;
+            ComplexFont = font.Typeface.FamilyName;
             Size = font.Size;
-            if (font.IsBold) Bold = font.IsBold;
-            if (font.IsItalic) Italic = font.IsItalic;
-            if ((textRun.TextDecorations & TextDecorations.Underline) != 0) UnderLine = eUnderLineType.Single;
-            if ((textRun.TextDecorations & TextDecorations.Strikeout) != 0) Strike = eStrikeType.Single;
+            if (font.Typeface.IsBold) Bold = font.Typeface.IsBold;
+            if (font.Typeface.IsItalic) Italic = font.Typeface.IsItalic;
+            if(font.Metrics.UnderlineThickness != null) UnderLine = eUnderLineType.Single;
+            if(font.Metrics.StrikeoutThickness != null) Strike = eStrikeType.Single;
         }
     }
 }

--- a/src/EPPlus/EPPlus/Style/XmlAccess/ExcelFontXml.cs
+++ b/src/EPPlus/EPPlus/Style/XmlAccess/ExcelFontXml.cs
@@ -29,11 +29,10 @@
  * Jan Källman		                Initial Release		        2009-10-01
  * Jan Källman		License changed GPL-->LGPL 2011-12-16
  *******************************************************************************/
+using SkiaSharp;
 using System;
-using SixLabors.ImageSharp;
 using System.Globalization;
 using System.Xml;
-using SixLabors.Fonts;
 
 namespace OfficeOpenXml.Style.XmlAccess
 {
@@ -269,14 +268,14 @@ namespace OfficeOpenXml.Style.XmlAccess
                 _verticalAlign = value;
             }
         }
-        public void SetFromTextRun(TextRun textRun)
+        public void SetFromFont(SKFont font)
         {
-            var font = textRun.Font;
+            Name = font.Typeface.FamilyName;
             Size = font.Size;
-            Bold = font.IsBold;
-            Italic = font.IsItalic;
-            UnderLine = (textRun.TextDecorations & TextDecorations.Underline) != 0;
-            Strike = (textRun.TextDecorations & TextDecorations.Strikeout) != 0;
+            Bold = font.Typeface.IsBold;
+            Italic = font.Typeface.IsItalic;
+            UnderLine = font.Metrics.UnderlineThickness != null;
+            Strike = font.Metrics.StrikeoutThickness != null;
         }
         public static float GetFontHeight(string name, float size)
         {

--- a/src/EPPlus/EPPlusTest/DrawingTest.cs
+++ b/src/EPPlus/EPPlusTest/DrawingTest.cs
@@ -8,8 +8,8 @@ using OfficeOpenXml;
 using OfficeOpenXml.Drawing;
 using OfficeOpenXml.Drawing.Chart;
 using OfficeOpenXml.Style;
-using SixLabors.Fonts;
 using SixLabors.ImageSharp;
+using SkiaSharp;
 
 namespace EPPlusTest
 {
@@ -293,11 +293,9 @@ namespace EPPlusTest
             ser.DataLabel.Fill.Color = Color.BlueViolet;
             ser.DataLabel.Font.Color = Color.White;
             ser.DataLabel.Font.Italic = true;
-            ser.DataLabel.Font.SetFromTextRun(
-                new TextRun
-                {
-                    Font = SystemFonts.CreateFont("bookman old style", CultureInfo.CurrentCulture, 8)
-                });
+            using var skFontTypeface = SKTypeface.FromFamilyName("bookman old style");
+            using var font = new SKFont(skFontTypeface, 8f);
+            ser.DataLabel.Font.SetFromFont(font);
             Assert.IsTrue(chrt.ChartType == eChartType.XYScatterSmoothNoMarkers, "Invalid Charttype");
             chrt.Series[0].Header = "Test serie";
             chrt = ws.Drawings.AddChart("ScatterChart2", eChartType.XYScatterSmooth) as ExcelScatterChart;
@@ -621,12 +619,9 @@ namespace EPPlusTest
             rt = (ws.Drawings["shape2"] as ExcelShape).RichText.Add("\r\nAdded formated richtext");
             rt.Bold = true;
             rt.Color = Color.DarkGoldenrod;
-            rt.SetFromTextRun(
-                new TextRun
-                {
-                    Font = SystemFonts.CreateFont("Times new roman", CultureInfo.CurrentCulture, 18),
-                    TextDecorations = TextDecorations.Underline
-                });
+            using var skFontTypeface = SKTypeface.FromFamilyName("Times new roman");
+            using var font = new SKFont(skFontTypeface, 18f);
+            rt.SetFromFont(font);
             rt.UnderLineColor = Color.Green;
 
 

--- a/src/EPPlus/EPPlusTest/WorkSheetTests.cs
+++ b/src/EPPlus/EPPlusTest/WorkSheetTests.cs
@@ -16,7 +16,7 @@ using OfficeOpenXml.Table;
 using System.Threading;
 using System.Globalization;
 using System.Threading.Tasks;
-using SixLabors.Fonts;
+using SkiaSharp;
 
 namespace EPPlusTest
 {
@@ -1890,11 +1890,9 @@ namespace EPPlusTest
             using (ExcelRange r = ws.Cells["A1:F1"])
             {
                 r.Merge = true;
-                r.Style.Font.SetFromTextRun(
-                    new TextRun
-                    {
-                        Font = SystemFonts.CreateFont("Arial", CultureInfo.CurrentCulture, 18, FontStyle.Italic)
-                    });
+                using var skFontTypeface = SKTypeface.FromFamilyName("Arial", SKFontStyle.Italic);
+                using var font = new SKFont(skFontTypeface, 18f);
+                r.Style.Font.SetFromFont(font);
                 r.Style.Font.Color.SetColor(Color.DarkRed);
                 r.Style.HorizontalAlignment = OfficeOpenXml.Style.ExcelHorizontalAlignment.CenterContinuous;
                 //r.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
@@ -2323,11 +2321,9 @@ namespace EPPlusTest
 
             var secondNamedStyle = _pck.Workbook.Styles.CreateNamedStyle("first", firstNamedStyle.Style).Style;
             secondNamedStyle.Font.Bold = true;
-            secondNamedStyle.Font.SetFromTextRun(
-                new TextRun
-                {
-                    Font = SystemFonts.CreateFont("Arial Black", CultureInfo.CurrentCulture, 8)
-                });
+            using var skFontTypeface = SKTypeface.FromFamilyName("Arial Black");
+            using var font = new SKFont(skFontTypeface, 8f);
+            secondNamedStyle.Font.SetFromFont(font);
             secondNamedStyle.Border.Bottom.Style = ExcelBorderStyle.Medium;
             secondNamedStyle.Border.Left.Style = ExcelBorderStyle.Medium;
 

--- a/src/Magicodes.ExporterAndImporter.Excel/ExcelExporter.cs
+++ b/src/Magicodes.ExporterAndImporter.Excel/ExcelExporter.cs
@@ -269,8 +269,7 @@ namespace Magicodes.ExporterAndImporter.Excel
                         helper.Export(sheetDataItems);
                     }
 
-                    return Task.FromResult(helper.CurrentExcelPackage.GetAsByteArray());
-                    //return Task.FromResult(NPOI.Extension.SaveToExcelWithXSSFWorkbook(helper.CurrentExcelPackage.GetAsByteArray())); // todo: use interface, not import NPOI directly
+                    return Task.FromResult(NPOI.Extension.SaveToExcelWithXSSFWorkbook(helper.CurrentExcelPackage.GetAsByteArray()));
                 }
             }
             else
@@ -307,7 +306,7 @@ namespace Magicodes.ExporterAndImporter.Excel
         {
             fileName.CheckExcelFileName();
             var bytes = await ExportAsByteArray<T>(dataItems);
-            //bytes = NPOI.Extension.SaveToExcelWithXSSFWorkbook(bytes); // todo: use interface, not import NPOI directly
+            bytes = NPOI.Extension.SaveToExcelWithXSSFWorkbook(bytes);
             return bytes.ToExcelExportFileInfo(fileName);
         }
 
@@ -369,8 +368,7 @@ namespace Magicodes.ExporterAndImporter.Excel
                         helper.AddExcelWorksheet();
                         helper.Export(sheetDataItems);
                     }
-                    return Task.FromResult(helper.CurrentExcelPackage.GetAsByteArray());
-                    //return Task.FromResult(NPOI.Extension.SaveToExcelWithXSSFWorkbook(helper.CurrentExcelPackage.GetAsByteArray())); // todo: use interface, not import NPOI directly
+                    return Task.FromResult(NPOI.Extension.SaveToExcelWithXSSFWorkbook(helper.CurrentExcelPackage.GetAsByteArray()));
                 }
             }
             else
@@ -404,9 +402,7 @@ namespace Magicodes.ExporterAndImporter.Excel
                         helper.AddExcelWorksheet();
                         helper.Export(sheetDataItems);
                     }
-
-                    return Task.FromResult(helper.CurrentExcelPackage.GetAsByteArray());
-                    //return Task.FromResult(NPOI.Extension.SaveToExcelWithXSSFWorkbook(helper.CurrentExcelPackage.GetAsByteArray())); // todo: use interface, not import NPOI directly
+                    return Task.FromResult(NPOI.Extension.SaveToExcelWithXSSFWorkbook(helper.CurrentExcelPackage.GetAsByteArray()));
                 }
             }
             else
@@ -482,8 +478,7 @@ namespace Magicodes.ExporterAndImporter.Excel
             helper.AddExporterHeaderInfoList(headerList);
             using (var ep = helper.ExportHeaders())
             {
-                return Task.FromResult(ep.GetAsByteArray());
-                //return Task.FromResult(NPOI.Extension.SaveToExcelWithXSSFWorkbook(ep.GetAsByteArray())); // todo: use interface, not import NPOI directly
+                return Task.FromResult(NPOI.Extension.SaveToExcelWithXSSFWorkbook(ep.GetAsByteArray()));
             }
         }
 
@@ -530,8 +525,7 @@ namespace Magicodes.ExporterAndImporter.Excel
             var helper = new ExportHelper<T>();
             using (var ep = helper.ExportHeaders())
             {
-                return Task.FromResult(ep.GetAsByteArray());
-                //return Task.FromResult(NPOI.Extension.SaveToExcelWithXSSFWorkbook(ep.GetAsByteArray()));  // 
+                return Task.FromResult(NPOI.Extension.SaveToExcelWithXSSFWorkbook(ep.GetAsByteArray()));  // 
             }
         }
 
@@ -611,8 +605,7 @@ namespace Magicodes.ExporterAndImporter.Excel
         {
             fileName.CheckExcelFileName();
             var bytes = await ExportAsByteArray(dataItems, exporterHeaderFilter, maxRowNumberOnASheet);
-            //bytes = NPOI.Extension.SaveToExcelWithXSSFWorkbook(bytes);  // todo: use interface, not import NPOI directly
-
+            bytes = NPOI.Extension.SaveToExcelWithXSSFWorkbook(bytes);
             return bytes.ToExcelExportFileInfo(fileName);
         }
 

--- a/src/Magicodes.ExporterAndImporter.Excel/Images/ImageExtensions.cs
+++ b/src/Magicodes.ExporterAndImporter.Excel/Images/ImageExtensions.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Magicodes.IE.Core;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Metadata;
 
 namespace Magicodes.IE.Excel.Images
 {
@@ -48,7 +49,13 @@ namespace Magicodes.IE.Excel.Images
             using (var wc = new WebClient())
             {
                 wc.Proxy = null;
-                return Image.Load(wc.OpenRead(url), out format);
+                var image = Image.Load(wc.OpenRead(url), out format);
+                if (image.Metadata.HorizontalResolution == 0 && image.Metadata.VerticalResolution == 0)
+                {
+                    image.Metadata.HorizontalResolution = ImageMetadata.DefaultHorizontalResolution;
+                    image.Metadata.VerticalResolution = ImageMetadata.DefaultVerticalResolution;
+                }
+                return image;
             }
         }
 

--- a/src/Magicodes.ExporterAndImporter.Excel/Magicodes.IE.Excel.csproj
+++ b/src/Magicodes.ExporterAndImporter.Excel/Magicodes.IE.Excel.csproj
@@ -12,5 +12,6 @@
   <ItemGroup>
     <ProjectReference Include="..\EPPlus\EPPlus\Magicodes.IE.EPPlus.csproj" />
     <ProjectReference Include="..\Magicodes.ExporterAndImporter.Core\Magicodes.IE.Core.csproj" />
+    <ProjectReference Include="..\Magicodes.IE.Excel.NPOI\Magicodes.IE.Excel.NPOI.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
1. As the sixlabors.Fonts has performance issue when it measure text.
![image](https://user-images.githubusercontent.com/1113475/198929513-7d5c2845-b622-41a4-9202-219058948c5e.png)
From the benchmark, you can see the the SixLabors is almost 9th or 10th slower than the System.Drawing Graphics, 45th slower than the SkiaSharp. 
The SixLabors will slower down the export speed when you use autofitcolumns
The SixLabors.Font is still in beta phase.

So, use the skiasharp to measure text.

2. add FangSong default font for measuring chinese or other texts(not in english), as no matter SixLabors, or SkiaSharp, all give unconsistent result compare with the System.Drawing when use the Calibri font.
![image](https://user-images.githubusercontent.com/1113475/198930345-f5f507e8-fa0f-44ec-b2d3-9c0492f7ed1c.png)

-------------------------------------------------------------------------------------
1. SixLabors.Fonts的MeasureText存在性能问题
通过Benchmark, SixLabor要比System.Drawing Graphics慢9到10倍，比SkiaSharp慢45倍左右
导致输出Excel文件时，定义了AutoFit时，会极大的减慢Excel导出速度。
目前SixLabors.Fonts仍然在Beta阶段。
此次，改为SkiaSharp来进行MeasureText操作
2. 增加了FangSong(仿宋)来对中文或其他非英文文本进行MeasureText操作，因为无论SixLabors, 还是SkiaSharp, 在通过Calibri字体计算文本长时，与System.Drawing相比都会输出错误的长度。