### PR TITLE
Fix DateTime cell convert to Nullable<DateTime>

### DIFF
--- a/src/Magicodes.ExporterAndImporter.Excel/Utility/ImportHelper.cs
+++ b/src/Magicodes.ExporterAndImporter.Excel/Utility/ImportHelper.cs
@@ -1438,8 +1438,15 @@ namespace Magicodes.ExporterAndImporter.Excel.Utility
 
                                         if (!DateTime.TryParse(cell.Text, out var date))
                                         {
-                                            AddRowDataError(rowIndex, col, $"{Resource.Value} {cell.Text} {Resource.PleaseFillInTheCorrectDateAndTimeFormat}");
-                                            break;
+                                            if (cell.Value is DateTime value)
+                                            {
+                                                date = value;
+                                            }
+                                            else
+                                            {
+                                                AddRowDataError(rowIndex, col, $"{Resource.Value} {cell.Text} {Resource.PleaseFillInTheCorrectDateAndTimeFormat}");
+                                                break;
+                                            }
                                         }
 
                                         SetValue(cell, dataItem, propertyInfo, date);


### PR DESCRIPTION
When parsing cell text of DateTime, the format "dd/MM/yy HH:mm" cannot be parsed by `DateTime.TryParse`.
Example file attached. [Test.xlsx](https://github.com/dotnetcore/Magicodes.IE/files/10317937/Test.xlsx)