### PR TITLE
Fix EPPLUS PackageReference Error

### DIFF
--- a/src/EPPlus/EPPlus/Magicodes.IE.EPPlus.csproj
+++ b/src/EPPlus/EPPlus/Magicodes.IE.EPPlus.csproj
@@ -49,7 +49,7 @@
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
 		<PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />		
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0"/>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
 		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
@@ -59,9 +59,9 @@
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
 		<PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
 		<PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" />
 		<PackageReference Include="Collections.Pooled" Version="2.0.0-preview.27" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.1.1" />
 		<PackageReference Include="SkiaSharp" Version="2.88.3" />

--- a/src/Stash/Magicodes.IE.Stash/Magicodes.IE.Stash.csproj
+++ b/src/Stash/Magicodes.IE.Stash/Magicodes.IE.Stash.csproj
@@ -27,6 +27,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CS-Script" Version="4.6.5" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\Magicodes.ExporterAndImporter.Excel\Magicodes.IE.Excel.csproj" />


### PR DESCRIPTION
最新版本因EPPLUS项目的PackageReference有误，导致以下问题：
1.Microsoft.Extensions.Configuration.Json隐式降级到了1.0.0，默认依赖了Newtonsoft.Json，所以项目Magicodes.IE.Stash.csproj可以正常编译。
2.在Nuget上依赖Microsoft.Extensions.Configuration.Json版本错误，导致.net6、7会解析依赖到3.0.0版本。
具体错误在CI管道上可见：https://dev.azure.com/xinlaiopencode/Magicodes.IE/_build/results?buildId=1872&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=24311d03-63ec-5098-c8e5-7df09da2b6d4