### PR TITLE
fix #543 The given key 'rId1' was not present in the dictionary

### DIFF
--- a/src/EPPlus/EPPlus/ExcelWorksheet.cs
+++ b/src/EPPlus/EPPlus/ExcelWorksheet.cs
@@ -1171,6 +1171,7 @@ namespace OfficeOpenXml
         private void LoadHyperLinks(XmlReader xr)
         {
             if (!ReadUntil(xr, "hyperlinks", "rowBreaks", "colBreaks")) return;
+            var rIdCache = new Dictionary<string, Uri>();
             while (xr.Read())
             {
                 if (xr.LocalName == "hyperlink")
@@ -1181,7 +1182,10 @@ namespace OfficeOpenXml
                     if (xr.GetAttribute("id", ExcelPackage.schemaRelationships) != null)
                     {
                         var rId = xr.GetAttribute("id", ExcelPackage.schemaRelationships);
-                        var uri = Part.GetRelationship(rId).TargetUri;
+                        if (!rIdCache.TryGetValue(rId,out var uri))
+                        {
+                            uri = Part.GetRelationship(rId).TargetUri;
+                        }
                         if (uri.IsAbsoluteUri)
                         {
                             try
@@ -1199,6 +1203,7 @@ namespace OfficeOpenXml
                         }
                         hl.RId = rId;
                         Part.DeleteRelationship(rId); //Delete the relationship, it is recreated when we save the package.
+                        rIdCache[rId] = uri;
                     }
                     else if (xr.GetAttribute("location") != null)
                     {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b5af546d-135f-49ea-a0fb-0400bf8d3f28)

same hyperlinks have same rId,so we need add a cache
#543 #487  #377 